### PR TITLE
Wire auto commands to phase workflows

### DIFF
--- a/hooks/phase-transition.js
+++ b/hooks/phase-transition.js
@@ -54,14 +54,19 @@ async function executeTransition(fromPhase, toPhase, context) {
   await savePhaseDeliverables(fromPhase, context);
 
   const newContext = await loadPhaseContext(toPhase, context);
-  await triggerCommand(`auto-${toPhase}`, newContext);
+  const workflowResult = await triggerCommand(`auto-${toPhase}`, newContext);
   await updateProjectState({
     currentPhase: toPhase,
     previousPhase: fromPhase,
     transitionTime: new Date().toISOString(),
     context: newContext
   });
-  return { newPhase: toPhase, context: newContext, message: await getTransitionMessage(toPhase) };
+  return {
+    newPhase: toPhase,
+    context: newContext,
+    workflowResult,
+    message: await getTransitionMessage(toPhase)
+  };
 }
 
 async function checkTransition(conversationContext, userMessage, currentPhase) {

--- a/lib/auto-commands.d.ts
+++ b/lib/auto-commands.d.ts
@@ -1,0 +1,7 @@
+export declare const COMMAND_PHASE_MAP: Record<string, string>;
+export declare function resolveAutoCommandPhase(command: string): string;
+export declare function executeAutoCommand(
+  command: string,
+  context: any,
+  bridge: { executePhaseWorkflow?: (phase: string, context: any) => any }
+): Promise<any>;

--- a/lib/auto-commands.js
+++ b/lib/auto-commands.js
@@ -1,0 +1,51 @@
+const AUTO_COMMAND_PREFIX = "auto-";
+
+const COMMAND_PHASE_MAP = {
+  analyst: "analyst",
+  analyze: "analyst",
+  pm: "pm",
+  plan: "pm",
+  architect: "architect",
+  architecture: "architect",
+  sm: "sm",
+  stories: "sm",
+  dev: "dev",
+  qa: "qa",
+  ux: "ux",
+  po: "po",
+};
+
+function resolveAutoCommandPhase(command) {
+  if (typeof command !== "string") {
+    throw new Error(`Invalid command type: ${typeof command}`);
+  }
+
+  if (!command.startsWith(AUTO_COMMAND_PREFIX)) {
+    throw new Error(`Unsupported command: ${command}`);
+  }
+
+  const key = command.slice(AUTO_COMMAND_PREFIX.length);
+  const phase = COMMAND_PHASE_MAP[key];
+
+  if (!phase) {
+    throw new Error(`Unknown auto-command phase for: ${command}`);
+  }
+
+  return phase;
+}
+
+async function executeAutoCommand(command, context, bridge) {
+  const phase = resolveAutoCommandPhase(command);
+
+  if (!bridge || typeof bridge.executePhaseWorkflow !== "function") {
+    throw new Error("BMAD bridge is not initialized");
+  }
+
+  return bridge.executePhaseWorkflow(phase, context);
+}
+
+module.exports = {
+  COMMAND_PHASE_MAP,
+  executeAutoCommand,
+  resolveAutoCommandPhase,
+};

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -7,6 +7,7 @@ import {
 import { z } from "zod";
 import * as path from "path";
 import * as fs from "fs/promises";
+import { executeAutoCommand } from "../lib/auto-commands.js";
 
 // Dynamic imports for CommonJS modules
 let ProjectState: any;
@@ -53,9 +54,8 @@ async function initializeProject(projectPath: string = process.cwd()) {
       return await bmadBridge.runAgent(agentId, context);
     },
     triggerCommand: async (command: string, context: any) => {
-      // Execute auto-commands
       console.error(`[MCP] Executing command: ${command}`);
-      return { success: true, command, context };
+      return executeAutoCommand(command, context, bmadBridge);
     },
     updateProjectState: async (updates: any) => {
       await projectState.updateState(updates);

--- a/test/phase-transition.workflow.test.js
+++ b/test/phase-transition.workflow.test.js
@@ -1,0 +1,46 @@
+const { bindDependencies, executeTransition } = require("../hooks/phase-transition");
+const { executeAutoCommand } = require("../lib/auto-commands");
+
+describe("executeTransition workflow integration", () => {
+  const updateProjectState = jest.fn();
+  const loadPhaseContext = jest.fn();
+  const saveDeliverable = jest.fn();
+  const executePhaseWorkflow = jest.fn();
+
+  beforeEach(() => {
+    updateProjectState.mockResolvedValue(undefined);
+    saveDeliverable.mockResolvedValue(undefined);
+    executePhaseWorkflow.mockResolvedValue({ ok: true });
+    loadPhaseContext.mockImplementation(async (phase, context) => ({
+      ...context,
+      enrichedBy: phase,
+    }));
+
+    bindDependencies({
+      triggerCommand: (command, context) =>
+        executeAutoCommand(command, context, { executePhaseWorkflow }),
+      updateProjectState,
+      loadPhaseContext,
+      saveDeliverable,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("invokes executePhaseWorkflow with derived phase and enriched context", async () => {
+    const context = { input: true };
+    const result = await executeTransition("analyst", "dev", context);
+
+    expect(loadPhaseContext).toHaveBeenCalledWith("dev", context);
+    expect(executePhaseWorkflow).toHaveBeenCalledWith("dev", {
+      input: true,
+      enrichedBy: "dev",
+    });
+    expect(updateProjectState).toHaveBeenCalledWith(
+      expect.objectContaining({ currentPhase: "dev", previousPhase: "analyst" })
+    );
+    expect(result.workflowResult).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- route auto-* commands through the BMAD bridge so phase workflows are executed
- capture workflow results during transitions and return them to the caller
- add regression coverage to ensure executeTransition invokes the bridge workflow with the enriched context

## Testing
- npm test *(fails: jest is not installed in the environment)*
- npm run build:mcp *(fails: project dependencies such as @modelcontextprotocol/sdk are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0639b60c8326adb4a1f1bcecd639