### PR TITLE
Fix previous state detection to use updatedAt timestamps

### DIFF
--- a/lib/brownfield-analyzer.js
+++ b/lib/brownfield-analyzer.js
@@ -319,11 +319,17 @@ class BrownfieldAnalyzer {
 
     if (await fs.pathExists(stateFile)) {
       const state = await fs.readJson(stateFile);
+      const lastUpdated =
+        state.updatedAt ||
+        state.lastUpdated ||
+        state.metadata?.updatedAt ||
+        state.metadata?.lastUpdated ||
+        null;
       return {
         exists: true,
         state,
         lastPhase: state.phase || state.currentPhase,
-        lastUpdated: state.lastUpdated,
+        lastUpdated,
       };
     }
 

--- a/test/brownfield-analyzer.previous-state.test.js
+++ b/test/brownfield-analyzer.previous-state.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs-extra');
+const os = require('node:os');
+const path = require('node:path');
+
+const { BrownfieldAnalyzer } = require('../lib/brownfield-analyzer');
+
+describe('BrownfieldAnalyzer.detectPreviousState', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-analyzer-'));
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.remove(tempDir);
+      tempDir = null;
+    }
+  });
+
+  it('surfaces updatedAt timestamps when present in stored state', async () => {
+    const analyzer = new BrownfieldAnalyzer(tempDir);
+    const stateDir = path.join(tempDir, '.bmad-invisible');
+    const stateFile = path.join(stateDir, 'state.json');
+    const storedState = {
+      phase: 'analyst',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    await fs.ensureDir(stateDir);
+    await fs.writeJson(stateFile, storedState);
+
+    const result = await analyzer.detectPreviousState();
+
+    expect(result.exists).toBe(true);
+    expect(result.state).toEqual(storedState);
+    expect(result.lastUpdated).toBe(storedState.updatedAt);
+  });
+
+  it('falls back to legacy lastUpdated timestamps when updatedAt is absent', async () => {
+    const analyzer = new BrownfieldAnalyzer(tempDir);
+    const stateDir = path.join(tempDir, '.bmad-invisible');
+    const stateFile = path.join(stateDir, 'state.json');
+    const storedState = {
+      phase: 'strategist',
+      lastUpdated: '2023-12-31T23:59:59.000Z',
+    };
+
+    await fs.ensureDir(stateDir);
+    await fs.writeJson(stateFile, storedState);
+
+    const result = await analyzer.detectPreviousState();
+
+    expect(result.exists).toBe(true);
+    expect(result.state).toEqual(storedState);
+    expect(result.lastUpdated).toBe(storedState.lastUpdated);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `detectPreviousState` surfaces the most recent timestamp from `updatedAt` with sensible fallbacks
- add unit coverage that validates `updatedAt` and legacy `lastUpdated` metadata are handled correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd8a0a502c8326b20dc354a31de436