### PR TITLE
Add API key validation to LLM client

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -12,6 +12,13 @@ class LLMClient {
     this.model = options.model || this.getDefaultModel();
     this.maxRetries = options.maxRetries || 3;
     this.retryDelay = options.retryDelay || 1000;
+
+    if (!this.apiKey) {
+      const envVar = this.getApiKeyEnvVarName();
+      throw new Error(
+        `Missing API key for provider "${this.provider}". Set the ${envVar} environment variable or provide an apiKey option.`,
+      );
+    }
   }
 
   getApiKeyFromEnv() {
@@ -29,6 +36,25 @@ class LLMClient {
       }
       default: {
         throw new Error(`Unknown LLM provider: ${this.provider}`);
+      }
+    }
+  }
+
+  getApiKeyEnvVarName() {
+    switch (this.provider) {
+      case 'claude': {
+        return 'ANTHROPIC_API_KEY';
+      }
+      case 'openai':
+      case 'gpt': {
+        return 'OPENAI_API_KEY';
+      }
+      case 'gemini':
+      case 'google': {
+        return 'GOOGLE_API_KEY';
+      }
+      default: {
+        return 'LLM_API_KEY';
       }
     }
   }

--- a/test/llm-client.test.js
+++ b/test/llm-client.test.js
@@ -1,0 +1,23 @@
+const { LLMClient } = require('../lib/llm-client');
+
+describe('LLMClient', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.LLM_PROVIDER;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('throws a descriptive error when initialized without credentials', () => {
+    expect(() => new LLMClient({ provider: 'claude' })).toThrow(
+      'Missing API key for provider "claude". Set the ANTHROPIC_API_KEY environment variable or provide an apiKey option.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- enforce explicit API key validation when creating the LLM client so missing credentials produce a clear error
- add a Jest test to confirm the client throws the descriptive error when credentials are absent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd8a17bed083268171c93d2e5fa1af