### PR TITLE
Enforce phase transition dependency binding

### DIFF
--- a/test/phase-transition.safety.test.js
+++ b/test/phase-transition.safety.test.js
@@ -1,17 +1,32 @@
-const { executeTransition } = require('../hooks/phase-transition');
-
-// Mock bindings
-jest.mock('../hooks/phase-transition', () => {
-  const actual = jest.requireActual('../hooks/phase-transition');
-  return {
-    ...actual,
-    __esModule: true,
-  };
-});
+function loadPhaseTransitionModule() {
+  let moduleExports;
+  jest.isolateModules(() => {
+    moduleExports = require('../hooks/phase-transition');
+  });
+  return moduleExports;
+}
 
 describe('phase-transition safety', () => {
   it('returns null when toPhase is falsy', async () => {
+    const { executeTransition } = loadPhaseTransitionModule();
     const res = await executeTransition('analyst', '', {});
     expect(res).toBeNull();
+  });
+
+  it('throws if required dependencies are missing on first bind', () => {
+    const { bindDependencies } = loadPhaseTransitionModule();
+    expect(() => bindDependencies({ triggerAgent: jest.fn() })).toThrow(
+      'Missing required dependencies for phase transition: saveDeliverable, loadPhaseContext',
+    );
+  });
+
+  it('allows rebinding once required dependencies were provided', () => {
+    const { bindDependencies } = loadPhaseTransitionModule();
+    const saveDeliverable = jest.fn();
+    const loadPhaseContext = jest.fn();
+
+    expect(() => bindDependencies({ saveDeliverable, loadPhaseContext })).not.toThrow();
+
+    expect(() => bindDependencies({ triggerAgent: jest.fn() })).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- make the phase transition save/load placeholders throw until dependencies are bound
- require saveDeliverable and loadPhaseContext in bindDependencies before allowing other hooks
- extend phase transition safety tests to cover the new dependency guardrails

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dec205ed1c8326ae53741b69d58fe9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Introduced explicit dependency binding with validation to prevent misconfiguration, improving stability without changing the public API.
  - Minor consistency tweaks to messages and internals; no user-facing behavior changes.

- Tests
  - Added tests for missing/invalid dependency handling and rebinding behavior.
  - Improved test isolation for more reliable results.

- Chores
  - Minor formatting and consistency updates.

No user-visible changes; this release focuses on reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->