### PR TITLE
Document V6 stability evaluation limitations

### DIFF
--- a/docs/versioning-and-releases.md
+++ b/docs/versioning-and-releases.md
@@ -153,3 +153,9 @@ If your local files don't match the published version after a release:
 - Verify NPM tokens are configured
 - Ensure branch protection allows workflow pushes
 ````
+
+## 🧪 V6 Stability Evaluation (April 2024)
+
+- Attempted to clone `bmad-upstream/v6-alpha`, but the repository URL is unavailable in the current environment, so no dependencies could be installed.
+- Because the codebase is inaccessible, V6 build and test pipelines could not be executed and workflow reliability could not be evaluated.
+- BMAD-Invisible migration prerequisites remain unmet until a valid V6 source is provided for verification.


### PR DESCRIPTION
## Summary
- record the failed attempt to clone `bmad-upstream/v6-alpha`
- document that V6 build/test pipelines and workflows could not be executed
- note that migration prerequisites remain unmet until a valid V6 source is available

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dedfb777bc832692fe27640fb74b81