### PR TITLE
Prototype V6 lane routing and document phase mapping

### DIFF
--- a/docs/v6-phase-lane-mapping.md
+++ b/docs/v6-phase-lane-mapping.md
@@ -1,0 +1,32 @@
+# V6 Phase Progression vs. Dual-Lane Workflows
+
+## Source Phases
+
+V6 alpha defines three primary phases prior to its forthcoming enterprise additions: **Analysis**, **Planning**, and an iterative **Development Cycle** that repeats per epic.【F:later-todo.md†L73-L114】 These phases emphasize explicit command-driven transitions and validation checkpoints.【F:later-todo.md†L73-L114】
+
+## Quick Lane Mapping
+
+Quick fixes and narrowly scoped requests align with a reduced V6 progression:
+
+1. **Analysis (Lite Variant)** – confirm the intent, dependencies, and acceptance details without spinning up the full research stack.
+2. **Development (Single-Pass)** – implement and validate the change in one focused loop, optionally pairing with a reviewer for safeguard.
+
+The prototype `v6.lane-selection-prototype` module converts the existing quick-lane heuristics into this shortened progression so V6 can skip formal planning assets when the signal strength strongly favors small scope.【F:lib/v6/lane-selection-module.js†L1-L86】
+
+## Complex Lane Mapping
+
+Complex initiatives continue to flow through the complete V6 experience:
+
+1. **Analysis (Deep-Dive)** – generate brainstorming artifacts, research notes, and the product brief.
+2. **Planning (Full-Stack)** – produce the PRD, architecture, and per-epic tech specs before entering build.
+3. **Development (Iterative Epic Cycle)** – run the story creation, context, implementation, and review loop per epic as V6 prescribes.【F:later-todo.md†L73-L114】【F:lib/v6/lane-selection-module.js†L10-L82】
+
+## Dual-Lane Compatibility Notes
+
+- **Lane Detection Reuse** – `lib/lane-selector.js` feeds directly into the V6 prototype without modification, showing the scoring model can act as an upstream signal for module routing.【F:lib/v6/lane-selection-module.js†L1-L86】
+- **Phase Blueprint Export** – the module exposes `getPhaseBlueprint` so orchestration layers can audit or override the default quick/complex progressions before execution.【F:lib/v6/lane-selection-module.js†L60-L83】
+- **Next Validation Step** – integrate with a real V6 runtime once module loading hooks are available to confirm command triggers and artifact writers receive the lane context.
+
+## Conclusion
+
+The study indicates that quick-lane work naturally collapses into a two-phase V6 path, while complex-lane work mirrors the canonical three-phase progression. The prototype demonstrates that our dual-lane selector can supply phase plans without altering its heuristics, suggesting migration risk is mainly in V6 runtime wiring rather than decision logic.【F:lib/v6/lane-selection-module.js†L1-L86】

--- a/later-todo.md
+++ b/later-todo.md
@@ -151,7 +151,7 @@ V6 represents a major architectural rewrite of BMAD-METHOD currently in alpha st
 - [ ] Invisible orchestrator compatible with v6 module system
 - [ ] MCP server integration maintained
 - [ ] Codex CLI compatibility verified
-- [ ] Dual-lane orchestration adaptable to v6 workflows
+- [ ] Dual-lane orchestration adaptable to v6 workflows _(lane selector prototype maps quick vs complex phase plans; validate against real V6 runtime when available)_
 
 ### Features Worth Cherry-Picking (Without Full Migration)
 

--- a/lib/v6/lane-selection-module.js
+++ b/lib/v6/lane-selection-module.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const { selectLane } = require('../lane-selector');
+
+const QUICK_PHASE_PROGRESSION = [
+  {
+    id: 'analysis',
+    variant: 'lite',
+    focus: 'Clarify request and confirm scope without full research sprint.',
+  },
+  {
+    id: 'development',
+    variant: 'single-pass-story',
+    focus: 'Implement change directly with lightweight validation.',
+  },
+];
+
+const COMPLEX_PHASE_PROGRESSION = [
+  {
+    id: 'analysis',
+    variant: 'deep-dive',
+    focus: 'Full research, brainstorming, and product brief generation.',
+  },
+  {
+    id: 'planning',
+    variant: 'full-stack',
+    focus: 'Produce PRD, architecture, and tech spec artifacts.',
+  },
+  {
+    id: 'development',
+    variant: 'iterative-epic-cycle',
+    focus: 'Story-by-story development with dedicated review steps.',
+  },
+];
+
+function buildEntryCriteria(phase, lane) {
+  if (phase.id === 'analysis') {
+    return lane === 'quick'
+      ? 'Confirm intent and dependencies in under one cycle.'
+      : 'Complete research artifacts and validate problem framing.';
+  }
+
+  if (phase.id === 'planning') {
+    return 'PRD.md, Architecture.md, and tech spec ready for next epic.';
+  }
+
+  if (phase.id === 'development') {
+    return lane === 'quick'
+      ? 'Single implement-and-verify pass with optional reviewer.'
+      : 'Story backlog prepared; review agent assigned for each story.';
+  }
+
+  return 'Follow V6 standard entry checklist.';
+}
+
+function normalizePhases(phases, lane) {
+  return phases.map((phase, index) => ({
+    ...phase,
+    order: index + 1,
+    entryCriteria: buildEntryCriteria(phase, lane),
+  }));
+}
+
+function createLaneSelectionModule(options = {}) {
+  const quickPhases = normalizePhases(options.quickPhases || QUICK_PHASE_PROGRESSION, 'quick');
+  const complexPhases = normalizePhases(
+    options.complexPhases || COMPLEX_PHASE_PROGRESSION,
+    'complex',
+  );
+
+  function planPhaseProgression(workItem, context = {}) {
+    if (!workItem || typeof workItem.description !== 'string') {
+      throw new Error('workItem.description (string) is required to plan phases.');
+    }
+
+    const decision = selectLane(workItem.description, context);
+    const phases = decision.lane === 'quick' ? quickPhases : complexPhases;
+
+    return {
+      ...decision,
+      phases,
+    };
+  }
+
+  return {
+    id: 'v6.lane-selection-prototype',
+    version: '0.1.0',
+    capabilities: ['phase-progression', 'lane-routing'],
+    planPhaseProgression,
+    getPhaseBlueprint(lane = 'complex') {
+      return lane === 'quick' ? quickPhases : complexPhases;
+    },
+  };
+}
+
+module.exports = {
+  createLaneSelectionModule,
+  QUICK_PHASE_PROGRESSION,
+  COMPLEX_PHASE_PROGRESSION,
+};

--- a/test/v6-lane-selection-module.test.js
+++ b/test/v6-lane-selection-module.test.js
@@ -1,0 +1,52 @@
+const { createLaneSelectionModule } = require('../lib/v6/lane-selection-module');
+
+describe('v6 lane selection module prototype', () => {
+  const module = createLaneSelectionModule();
+
+  it('routes quick work to rapid phase progression', () => {
+    const result = module.planPhaseProgression({
+      description: 'Fix typo in README and remove console log',
+    });
+
+    expect(result.lane).toBe('quick');
+    expect(result.phases).toHaveLength(2);
+    expect(result.phases[0]).toMatchObject({
+      id: 'analysis',
+      variant: 'lite',
+      order: 1,
+    });
+    expect(result.phases[1]).toMatchObject({
+      id: 'development',
+      variant: 'single-pass-story',
+      order: 2,
+    });
+  });
+
+  it('routes complex work to full phase progression', () => {
+    const result = module.planPhaseProgression({
+      description: 'Implement new authentication feature touching API and database',
+    });
+
+    expect(result.lane).toBe('complex');
+    expect(result.phases).toHaveLength(3);
+    expect(result.phases[0]).toMatchObject({
+      id: 'analysis',
+      variant: 'deep-dive',
+      order: 1,
+    });
+    expect(result.phases[1]).toMatchObject({
+      id: 'planning',
+      variant: 'full-stack',
+      order: 2,
+    });
+    expect(result.phases[2]).toMatchObject({
+      id: 'development',
+      variant: 'iterative-epic-cycle',
+      order: 3,
+    });
+  });
+
+  it('throws if work item description missing', () => {
+    expect(() => module.planPhaseProgression({})).toThrow(/workItem\.description/);
+  });
+});


### PR DESCRIPTION
## Summary
- document how V6 analysis, planning, and development phases align with quick and complex dual lanes
- add a prototype V6 module that reuses the existing lane selector to produce lane-aware phase progressions
- cover the prototype with Jest tests to validate quick vs complex routing behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dedfbd90408326a59aebd9f095394b