### PR TITLE
Align invisible orchestration with V6 scale levels

### DIFF
--- a/agents/invisible-orchestrator.md
+++ b/agents/invisible-orchestrator.md
@@ -27,6 +27,28 @@ You are a helpful project assistant. Your job is to guide users through project 
 
 ## How You Work
 
+### Scale-Adaptive Alignment (V6 Levels 0-4)
+
+Internally map every conversation to the appropriate V6 scale level before responding. Levels describe the breadth of work, from **Level 0 simple minor tasks** up to **Level 4 massive enterprise-scale efforts**.【F:later-todo.md†L1-L32】 Combine the lane selector signal with these guidelines:
+
+- **Level 0 (Quick lane dominant + trivial scope)**
+  - Applies when the lane selector marks Level 0.
+  - Stay in the current user-visible flow and deliver a concise fix. Skip PM/Architect stages unless user explicitly asks for broader change.
+- **Level 1 (Quick lane, light planning)**
+  - Provide just enough clarification to confirm impact, then move straight to implementation guidance.
+  - Optionally note follow-up debt internally if the change may grow.
+- **Level 2 (Complex lane baseline)**
+  - Run the standard invisible sequence (Analyst → PM → Architect → SM → Dev) but keep artifacts lean.
+  - Focus on the immediate feature/epic that triggered the request.
+- **Level 3 (Complex lane with multi-scope signals)**
+  - Expect multi-file or multi-team coordination. Ensure architecture and story artifacts are fully detailed.
+  - Schedule checkpoints with the user between major transitions (Architect → SM, SM → Dev, Dev → QA).
+- **Level 4 (Enterprise scale)**
+  - Trigger enhanced diligence: broaden discovery questions, capture risks, and double-check validation with the user at each phase.
+  - When available, coordinate with specialized agents (QA, UX) even if the user does not explicitly request them.
+
+Record the inferred level alongside lane decisions via MCP logging so downstream tools can react accordingly.
+
 ### 1. Track Project State with MCP
 
 Use these MCP tools throughout the conversation:

--- a/docs/v6-level-alignment-note.md
+++ b/docs/v6-level-alignment-note.md
@@ -1,0 +1,27 @@
+# V6 Scale-Adaptive Workflow Alignment
+
+## Context
+
+The V6 documentation introduces scale-adaptive workflows that classify engagements from **Level 0 simple minor tasks** to **Level 4 massive enterprise-scale efforts**.【F:later-todo.md†L14-L31】 The invisible orchestrator previously differentiated only between quick and complex lanes, so we mapped these levels onto existing automation and captured remaining gaps.
+
+## Level Mapping Summary
+
+| V6 Level | Invisible Orchestration Handling                                                                                                                                                                                            | Notes                                                            |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Level 0  | Quick lane with new Level 0 classification, skipping heavy PM/Architect phases while staying invisible to the user.【F:agents/invisible-orchestrator.md†L21-L37】【F:lib/lane-selector.js†L118-L148】                       | Works for trivial fixes and housekeeping tasks.                  |
+| Level 1  | Quick lane with confirmation + implementation guidance; keeps planning lightweight while logging the inferred level for downstream tools.【F:agents/invisible-orchestrator.md†L21-L37】【F:lib/lane-selector.js†L118-L148】 | Ensures slightly broader requests still receive context capture. |
+| Level 2  | Complex lane baseline; retains standard Analyst→Dev progression but encourages lean artifacts to avoid overproduction.【F:agents/invisible-orchestrator.md†L29-L37】【F:lib/lane-selector.js†L149-L170】                    | Matches most focused feature work.                               |
+| Level 3  | Complex lane with multi-scope signals; enforces richer architecture/story outputs and extra checkpoints.【F:agents/invisible-orchestrator.md†L33-L37】【F:lib/lane-selector.js†L149-L170】                                  | Aligns with multi-epic coordination.                             |
+| Level 4  | Complex lane with enterprise-scale triggers; requires broader discovery, explicit risk capture, and cross-agent collaboration.【F:agents/invisible-orchestrator.md†L33-L37】【F:lib/lane-selector.js†L171-L186】            | Designed for large programs and multi-phase engagements.         |
+
+## Gaps & Refactors
+
+- **Source Detail for Levels 1-3**: V6 documentation only specifies Level 0 and Level 4 explicitly; intermediate guidance remains inferred. Capture future clarifications once official definitions are published.【F:later-todo.md†L14-L31】
+- **Lane Selector Signal Expansion**: The selector now records `level` and `levelRationale`, but downstream consumers (e.g., MCP analytics, reporting) must be updated to read these fields.
+- **Enterprise Safeguards**: Level 4 heuristics rely on high-complexity keywords and context flags. Additional signals (team size, compliance/regulatory requirements) should be incorporated when data becomes available.
+
+## Next Steps
+
+1. Wire the new level metadata into MCP decision logs and dashboards.
+2. Revisit heuristics when upstream V6 documentation provides richer Level 1–3 definitions.
+3. Extend orchestrator validation prompts to optionally mention multi-team alignment when Level ≥ 3 (without exposing methodology terminology).

--- a/later-todo.md
+++ b/later-todo.md
@@ -138,7 +138,7 @@ V6 represents a major architectural rewrite of BMAD-METHOD currently in alpha st
 ### Good Reasons to Migrate
 
 - [ ] V6 reaches beta or stable release
-- [ ] Scale-adaptive workflows (0-4) align with invisible orchestration
+- [x] Scale-adaptive workflows (0-4) align with invisible orchestration (see `docs/v6-level-alignment-note.md`)
 - [ ] Modular plugin system benefits our expansion strategy
 - [ ] JIT context injection improves invisible agent performance
 - [ ] Web bundles become production-ready

--- a/lib/lane-selector.js
+++ b/lib/lane-selector.js
@@ -184,12 +184,21 @@ function selectLane(userMessage, context = {}) {
     rationale = 'Task appears small enough for quick lane. Can escalate to complex if needed.';
   }
 
+  const levelDecision = classifyScaleLevel({
+    factors,
+    quickScore,
+    complexScore,
+    context,
+  });
+
   return {
     lane,
     confidence,
     rationale,
     factors,
     scores: { quick: quickScore, complex: complexScore },
+    level: levelDecision.level,
+    levelRationale: levelDecision.rationale,
   };
 }
 
@@ -234,6 +243,62 @@ function buildRationale(selectedLane, factors, quickScore, complexScore) {
 }
 
 /**
+ * Map lane decision context onto V6 scale-adaptive levels (0-4)
+ */
+function classifyScaleLevel({ factors, quickScore, complexScore, context = {} }) {
+  const rationale = [];
+  const normalizedContext = context || {};
+
+  const quickDominant = quickScore >= complexScore;
+
+  if (quickDominant) {
+    rationale.push('quick lane indicators dominate');
+
+    if (factors.quickFixKeywords > 0 && factors.singleFileScope && factors.messageLength < 120) {
+      rationale.push('single-file quick fix with minimal coordination');
+      return {
+        level: 0,
+        rationale: `Level 0: ${rationale.join('; ')}`,
+      };
+    }
+
+    rationale.push('limited blast radius but still requires some planning');
+    return {
+      level: 1,
+      rationale: `Level 1: ${rationale.join('; ')}`,
+    };
+  }
+
+  // Complex dominance defaults to Level 2 (coordinated feature delivery)
+  let level = 2;
+  rationale.push('complex lane indicators require orchestration');
+
+  if (factors.complexKeywords >= 2 || normalizedContext.hasExistingPRD) {
+    level = Math.max(level, 3);
+    rationale.push('multiple complex signals or existing PRD context');
+  }
+
+  if (factors.multiFileScope || factors.messageLength > 350) {
+    level = Math.max(level, 3);
+    rationale.push('broad multi-file or detailed scope');
+  }
+
+  if (
+    (factors.multiFileScope && factors.complexKeywords >= 3) ||
+    normalizedContext.projectComplexity === 'high' ||
+    (normalizedContext.previousPhase && normalizedContext.previousPhase !== 'quick')
+  ) {
+    level = 4;
+    rationale.push('enterprise-scale indicators (multi-phase, high complexity)');
+  }
+
+  return {
+    level,
+    rationale: `Level ${level}: ${rationale.join('; ')}`,
+  };
+}
+
+/**
  * Log lane decision to decisions.jsonl
  */
 async function logDecision(projectPath, decision, userMessage) {
@@ -249,6 +314,8 @@ async function logDecision(projectPath, decision, userMessage) {
     rationale: decision.rationale,
     factors: decision.factors,
     scores: decision.scores,
+    level: decision.level,
+    levelRationale: decision.levelRationale,
   };
 
   await fs.appendFile(decisionsFile, JSON.stringify(entry) + '\n');
@@ -294,4 +361,5 @@ module.exports = {
   getDecisionHistory,
   QUICK_FIX_KEYWORDS,
   COMPLEX_KEYWORDS,
+  classifyScaleLevel,
 };


### PR DESCRIPTION
## Summary
- map V6 scale-adaptive levels onto the invisible orchestrator guidance to clarify how each level behaves
- extend the lane selector to classify level 0-4 heuristics and log the level rationale alongside lane decisions
- add an architecture note documenting the new mapping and update migration tracking to reflect the alignment work

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dedfb0a6bc83268b48bbdebf5612fb