### PR TITLE
Introduce context injector pipeline for invisible JIT developer prompts

### DIFF
--- a/docs/jit-context-integration-plan.md
+++ b/docs/jit-context-integration-plan.md
@@ -1,0 +1,33 @@
+# JIT Context Injection Integration Plan
+
+## V6 Story Context Recap
+
+- V6 introduces a "story-context" command that generates just-in-time developer context immediately after the scrum master drafts a story, prior to the developer execution step.【F:later-todo.md†L86-L109】
+- The V6 flow replaces always-on context files with targeted expertise injections (for example, attaching a specialist persona for UI work) so the developer prompt is purpose-built for the current story.【F:later-todo.md†L42-L56】
+- Fresh context validation tasks optionally run in clean windows to confirm that the generated context is bias-free before coding begins.【F:later-todo.md†L58-L70】
+
+## Invisible Orchestrator Adaptation Strategy
+
+1. **Context Injector Pipeline**
+   - Extend `BMADBridge` with a pluggable context injector registry so runtime components can contribute targeted sections before a prompt is sent to any agent.
+   - Each injector receives the agent id and current execution context and can return structured sections (`title`, `body`, `priority`) that are merged into the user message for the LLM.【F:lib/bmad-bridge.js†L12-L23】【F:lib/bmad-bridge.js†L101-L171】
+
+2. **Developer Story Context Injector**
+   - Register a developer-specific injector from the MCP runtime after the bridge initializes. The injector aggregates:
+     - The latest story deliverable authored by the scrum master (`docs/` output captured in project state).
+     - Consolidated requirements, decisions, and next steps tracked by the orchestrator state store.
+     - Recent user/assistant conversation snippets for situational awareness.【F:src/mcp-server/runtime.ts†L9-L124】【F:src/mcp-server/runtime.ts†L214-L250】
+   - Sections are prioritized (high/medium/low) so future heuristics can decide ordering or trimming if the prompt needs to shrink.
+
+3. **Prompt Assembly Changes**
+   - Updated prompt builder appends an explicit "Targeted Context Injection" section, mirroring V6’s practice of handing the developer a curated packet directly inside the LLM conversation.【F:lib/bmad-bridge.js†L76-L115】
+
+4. **Extensibility Hooks**
+   - Runtime keeps injector registration idempotent, enabling future additions (e.g., QA, UX) without duplicate sections.
+   - Bridge exposes methods to register or clear injectors, letting other subsystems (phase hooks, CLI) compose their own V6-inspired context packages.【F:lib/bmad-bridge.js†L117-L171】
+
+## Next Steps
+
+- Expand project state to persist structured story context (e.g., acceptance criteria, reference links) so injectors can output richer sections.
+- Introduce validation hooks similar to V6’s `validate-story-context` command by running injectors inside a clean LLM session for audit trails.
+- Evaluate model token budgets once additional sections are enabled and add heuristics for trimming or summarizing when necessary.

--- a/later-todo.md
+++ b/later-todo.md
@@ -140,7 +140,7 @@ V6 represents a major architectural rewrite of BMAD-METHOD currently in alpha st
 - [ ] V6 reaches beta or stable release
 - [ ] Scale-adaptive workflows (0-4) align with invisible orchestration
 - [ ] Modular plugin system benefits our expansion strategy
-- [ ] JIT context injection improves invisible agent performance
+- [x] JIT context injection improves invisible agent performance — integration plan recorded in `docs/jit-context-integration-plan.md` and context injector scaffolding implemented
 - [ ] Web bundles become production-ready
 - [ ] Community adoption makes it the standard
 

--- a/lib/bmad-bridge.js
+++ b/lib/bmad-bridge.js
@@ -13,6 +13,7 @@ class BMADBridge {
     this.bmadCorePath = options.bmadCorePath || path.join(__dirname, '..', 'bmad-core');
     this.llmClient = options.llmClient || new LLMClient();
     this.coreConfig = null;
+    this.contextInjectors = [];
   }
 
   /**
@@ -65,8 +66,11 @@ class BMADBridge {
     // Build system prompt from agent persona
     const systemPrompt = this.buildAgentSystemPrompt(agent);
 
+    // Allow registered injectors to enrich the context before prompt assembly
+    const enrichedContext = await this.applyContextInjectors(agentId, context, agent);
+
     // Build user message from context
-    const userMessage = this.buildContextMessage(context);
+    const userMessage = this.buildContextMessage(enrichedContext);
 
     // Call LLM with agent persona
     const response = await this.llmClient.chat([{ role: 'user', content: userMessage }], {
@@ -151,7 +155,95 @@ class BMADBridge {
       message += `Additional Context:\n${context.additionalContext}\n`;
     }
 
+    if (Array.isArray(context.targetedSections) && context.targetedSections.length > 0) {
+      message += '\nTargeted Context Injection:\n';
+      for (const section of context.targetedSections) {
+        const title = section.title || 'Context';
+        const body = section.body || '';
+        const priority = section.priority == null ? '' : ` (priority: ${section.priority})`;
+        message += `\n### ${title}${priority}\n${body}\n`;
+      }
+      message += '\n';
+    }
+
     return message || 'Please proceed with your role.';
+  }
+
+  /**
+   * Register a context injector that can add targeted prompt sections
+   * @param {Function} injector - async function ({ agentId, context, agent, bridge }) => ({ merge?, sections? })
+   */
+  registerContextInjector(injector) {
+    if (typeof injector === 'function') {
+      this.contextInjectors.push(injector);
+    }
+  }
+
+  /**
+   * Clear all registered context injectors
+   */
+  clearContextInjectors() {
+    this.contextInjectors = [];
+  }
+
+  /**
+   * Apply registered context injectors to enrich the base context
+   */
+  async applyContextInjectors(agentId, context = {}, agent = null) {
+    if (this.contextInjectors.length === 0) {
+      return context;
+    }
+
+    let workingContext = { ...context };
+    const aggregatedSections = Array.isArray(workingContext.targetedSections)
+      ? [...workingContext.targetedSections]
+      : [];
+
+    for (const injector of this.contextInjectors) {
+      try {
+        const result = await injector({
+          agentId,
+          context: workingContext,
+          agent,
+          bridge: this,
+        });
+
+        if (!result) {
+          continue;
+        }
+
+        if (result.merge && typeof result.merge === 'object') {
+          workingContext = {
+            ...workingContext,
+            ...result.merge,
+          };
+        }
+
+        if (Array.isArray(result.sections)) {
+          for (const section of result.sections) {
+            if (section && typeof section === 'object') {
+              aggregatedSections.push(section);
+            }
+          }
+        }
+      } catch (error) {
+        // Swallow injector errors but surface a breadcrumb in the context for debugging
+        aggregatedSections.push({
+          title: 'Context Injector Warning',
+          body: `Injector error for agent ${agentId}: ${error instanceof Error ? error.message : error}`,
+          priority: 'low',
+        });
+      }
+    }
+
+    if (aggregatedSections.length > 0) {
+      workingContext = {
+        ...workingContext,
+        targetedSections: aggregatedSections,
+      };
+    }
+
+    return workingContext;
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a pluggable context injector pipeline to the BMAD bridge so runtime code can enrich prompts before agent calls
- register a developer-focused injector in the MCP runtime that assembles story, requirement, decision, and conversation context
- document the integration plan and mark the corresponding migration TODO item as completed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dedfb28fc48326a195f1409162ac54