### PR TITLE
Add story context validation checkpoint and tooling

### DIFF
--- a/docs/STORY_CONTEXT.md
+++ b/docs/STORY_CONTEXT.md
@@ -46,3 +46,24 @@ Additional enrichers can be registered to append design docs, recent decisions, 
 3. Run the invisible workflow as normal; when the orchestrator reaches development, the enriched packet is automatically included for the `dev` and `qa` agents.
 
 This approach keeps the workflow silent for end users while achieving parity with V6’s story preparedness philosophy.
+
+## Validation & Audit Trail
+
+- `story_context_validation` is a new checkpoint that replays the registered enrichers inside a disposable reviewer lane before development begins.
+- Enable the gate with the MCP tool:
+  ```json
+  {
+    "name": "configure_developer_lane",
+    "arguments": { "validateStoryContext": true }
+  }
+  ```
+- When enabled, transitioning into the developer phase automatically calls `run_story_context_validation`. Any missing persona fragments, acceptance criteria, or definition of done entries will block the transition and capture a record in `.bmad-invisible/reviews.json` via `ProjectState.recordReviewOutcome()`.
+- Operators can also run the checkpoint manually to inspect the enriched packet:
+  ```json
+  {
+    "name": "run_story_context_validation",
+    "arguments": { "notes": "Spot check before coding" }
+  }
+  ```
+
+This mirrors the optional V6 `validate-story-context` command while preserving the invisible workflow.

--- a/docs/review-checkpoints.md
+++ b/docs/review-checkpoints.md
@@ -4,11 +4,12 @@ The invisible orchestrator now enforces three governance gates that run on a fre
 
 ## Checkpoint Catalog
 
-| Checkpoint ID                | Reviewer Lane                  | Scope                                                                     | Expected Output                                                                                        |
-| ---------------------------- | ------------------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `pm_plan_review`             | `review` (Product Owner)       | Validates PRD, roadmap, and delivery risks after the PM plan is approved. | JSON payload with status (`approve`, `revise`, or `block`), summary, risk list, and follow-up actions. |
-| `architecture_design_review` | `review` (Principal Architect) | Audits architecture/system design packages before stories are written.    | Same JSON schema focusing on feasibility and integration risks.                                        |
-| `story_scope_review`         | `review` (Senior QA)           | Confirms stories/epics are testable and scoped prior to implementation.   | Same JSON schema with emphasis on acceptance coverage and testability.                                 |
+| Checkpoint ID                | Reviewer Lane                  | Scope                                                                         | Expected Output                                                                                        |
+| ---------------------------- | ------------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `pm_plan_review`             | `review` (Product Owner)       | Validates PRD, roadmap, and delivery risks after the PM plan is approved.     | JSON payload with status (`approve`, `revise`, or `block`), summary, risk list, and follow-up actions. |
+| `architecture_design_review` | `review` (Principal Architect) | Audits architecture/system design packages before stories are written.        | Same JSON schema focusing on feasibility and integration risks.                                        |
+| `story_scope_review`         | `review` (Senior QA)           | Confirms stories/epics are testable and scoped prior to implementation.       | Same JSON schema with emphasis on acceptance coverage and testability.                                 |
+| `story_context_validation`   | `review` (Context Validator)   | Replays story-context enrichers in isolation before development when enabled. | Auto-recorded outcome with persona/section snapshot; blocks dev transition on `block` status.          |
 
 ## Running a Review
 
@@ -25,7 +26,7 @@ The invisible orchestrator now enforces three governance gates that run on a fre
    ```
 3. The MCP server instantiates a dedicated `BMADBridge` wired to the `review` lane. Deliverables from the source phase plus the overall project snapshot are passed as context.
 4. The reviewer agent responds with JSON. Results are stored automatically via `ProjectState.recordReviewOutcome()` in `.bmad-invisible/reviews.json` for auditability.
-5. If the reviewer returns `revise` or `block`, stay in the current phase, address the findings with the user, and re-run the checkpoint.
+5. If the reviewer returns `revise` or `block`, stay in the current phase, address the findings with the user, and re-run the checkpoint. When story-context validation is enabled, a `block` result prevents the developer transition automatically.
 
 ## Data Capture
 

--- a/lib/story-context-validator.js
+++ b/lib/story-context-validator.js
@@ -1,0 +1,216 @@
+'use strict';
+
+const STORY_CONTEXT_VALIDATION_CHECKPOINT = 'story_context_validation';
+
+function normalizeStoryDeliverable(deliverable) {
+  if (!deliverable) {
+    return null;
+  }
+
+  if (typeof deliverable === 'string') {
+    return { content: deliverable };
+  }
+
+  if (deliverable.content && typeof deliverable.content === 'string') {
+    return {
+      ...deliverable,
+      content: deliverable.content,
+    };
+  }
+
+  if (deliverable.content && typeof deliverable.content === 'object') {
+    return { ...deliverable.content };
+  }
+
+  return { ...deliverable };
+}
+
+function findSection(sections = [], pattern) {
+  return sections.find((section) => {
+    const title = section?.title;
+    return typeof title === 'string' && pattern.test(title);
+  });
+}
+
+function hasBody(section) {
+  if (!section) {
+    return false;
+  }
+  const body = section.body;
+  if (body == null) {
+    return false;
+  }
+  if (typeof body === 'string') {
+    return body.trim().length > 0;
+  }
+  if (Array.isArray(body)) {
+    return body.length > 0;
+  }
+  if (typeof body === 'object') {
+    return Object.keys(body).length > 0;
+  }
+  return false;
+}
+
+async function runStoryContextValidation({
+  projectState,
+  createLLMClient,
+  BMADBridge,
+  lane = 'review',
+  notes,
+  trigger,
+  log = () => {},
+  checkpointId = STORY_CONTEXT_VALIDATION_CHECKPOINT,
+}) {
+  if (!projectState || typeof projectState.recordReviewOutcome !== 'function') {
+    throw new TypeError('projectState with recordReviewOutcome is required');
+  }
+  if (typeof createLLMClient !== 'function') {
+    throw new TypeError('createLLMClient function is required');
+  }
+  if (typeof BMADBridge !== 'function') {
+    throw new TypeError('BMADBridge constructor is required');
+  }
+
+  const llmClient = await createLLMClient(lane);
+  const bridge = new BMADBridge({ llmClient });
+
+  if (typeof bridge.initialize === 'function') {
+    await bridge.initialize();
+  }
+
+  let agent = { id: 'dev' };
+  if (typeof bridge.loadAgent === 'function') {
+    try {
+      agent = await bridge.loadAgent('dev');
+    } catch (error) {
+      log(
+        `[StoryContextValidation] Failed to load dev agent persona: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  const storyDeliverable = projectState.getDeliverable
+    ? projectState.getDeliverable('sm', 'story')
+    : null;
+  const normalizedStory = normalizeStoryDeliverable(storyDeliverable);
+
+  const validationContext = {
+    projectPath: projectState.projectPath,
+    story: normalizedStory,
+    requirements: projectState.state?.requirements || {},
+    decisions: projectState.state?.decisions || {},
+    sprintPlan: projectState.getDeliverable
+      ? (projectState.getDeliverable('sm', 'sprint_plan')?.content ?? null)
+      : null,
+    deliverables: projectState.getPhaseDeliverables ? projectState.getPhaseDeliverables('sm') : {},
+  };
+
+  let enrichment = {
+    context: validationContext,
+    personaFragments: [],
+    contextSections: [],
+  };
+
+  if (typeof bridge.applyContextEnrichers === 'function') {
+    enrichment = await bridge.applyContextEnrichers(agent, validationContext);
+  }
+
+  const personaFragments = Array.isArray(enrichment?.personaFragments)
+    ? enrichment.personaFragments
+    : Array.isArray(enrichment?.persona)
+      ? enrichment.persona
+      : [];
+  const contextSections = Array.isArray(enrichment?.contextSections)
+    ? enrichment.contextSections
+    : Array.isArray(enrichment?.sections)
+      ? enrichment.sections
+      : [];
+
+  const issues = [];
+
+  const hasStoryPayload = Boolean(
+    normalizedStory &&
+      (normalizedStory.content ||
+        normalizedStory.path ||
+        normalizedStory.summary ||
+        normalizedStory.description ||
+        (Array.isArray(normalizedStory.acceptanceCriteria) &&
+          normalizedStory.acceptanceCriteria.length > 0) ||
+        (Array.isArray(normalizedStory.definitionOfDone) &&
+          normalizedStory.definitionOfDone.length > 0) ||
+        normalizedStory.title),
+  );
+
+  if (!hasStoryPayload) {
+    issues.push('Story payload is missing content or path for enrichment.');
+  }
+
+  const acceptanceSection = findSection(contextSections, /acceptance criteria/i);
+  if (!hasBody(acceptanceSection)) {
+    issues.push('Acceptance Criteria section missing from enriched context.');
+  }
+
+  const definitionOfDoneSection = findSection(contextSections, /definition of done/i);
+  if (!hasBody(definitionOfDoneSection)) {
+    issues.push('Definition of Done section missing from enriched context.');
+  }
+
+  if (personaFragments.length === 0) {
+    issues.push('No persona fragments generated for developer lane.');
+  }
+
+  const status = issues.length > 0 ? 'block' : 'approve';
+
+  const record = await projectState.recordReviewOutcome(checkpointId, {
+    phase: 'sm',
+    reviewer: 'story_context_validator',
+    lane,
+    status,
+    summary:
+      status === 'approve'
+        ? 'Story context enrichment validated successfully.'
+        : 'Story context enrichment failed validation.',
+    risks: issues,
+    followUp: issues,
+    additionalNotes: notes ?? undefined,
+    trigger,
+    enrichment: {
+      personaFragments,
+      contextSections,
+      context: enrichment?.context || validationContext,
+    },
+  });
+
+  return {
+    checkpoint: checkpointId,
+    status,
+    issues,
+    record,
+    enrichment,
+  };
+}
+
+async function ensureStoryContextReadyForDevelopment(options) {
+  const result = await runStoryContextValidation(options);
+
+  if (result.status !== 'approve') {
+    const message =
+      result.issues.length > 0
+        ? `Story context validation failed: ${result.issues.join('; ')}`
+        : 'Story context validation failed.';
+    const error = new Error(message);
+    error.validation = result;
+    throw error;
+  }
+
+  return result;
+}
+
+module.exports = {
+  STORY_CONTEXT_VALIDATION_CHECKPOINT,
+  runStoryContextValidation,
+  ensureStoryContextReadyForDevelopment,
+};

--- a/test/story-context-validation.test.js
+++ b/test/story-context-validation.test.js
@@ -1,0 +1,151 @@
+const {
+  STORY_CONTEXT_VALIDATION_CHECKPOINT,
+  runStoryContextValidation,
+  ensureStoryContextReadyForDevelopment,
+} = require('../lib/story-context-validator');
+
+function createProjectState(overrides = {}) {
+  const records = [];
+  const base = {
+    projectPath: '/tmp/project',
+    state: {
+      requirements: { foo: 'bar' },
+      decisions: { stack: 'node' },
+    },
+    getDeliverable: jest.fn((phase, type) => {
+      if (phase === 'sm' && type === 'story') {
+        return {
+          content: {
+            title: 'Sample Story',
+            acceptanceCriteria: ['passes validation'],
+            definitionOfDone: ['tests updated'],
+          },
+        };
+      }
+      return null;
+    }),
+    getPhaseDeliverables: jest.fn(() => ({ story: { content: 'Story content' } })),
+    async recordReviewOutcome(checkpoint, details) {
+      const record = { checkpoint, ...details, timestamp: '2024-01-01T00:00:00Z' };
+      records.push(record);
+      return record;
+    },
+    records,
+  };
+
+  return Object.assign(base, overrides);
+}
+
+function createBridgeClass(enrichment) {
+  const instances = [];
+
+  return class FakeBridge {
+    constructor() {
+      instances.push(this);
+      this.llmClient = null;
+    }
+
+    async initialize() {
+      this.initialized = true;
+    }
+
+    async loadAgent(agentId) {
+      this.loadedAgentId = agentId;
+      return { id: agentId };
+    }
+
+    async applyContextEnrichers(agent, context) {
+      this.lastAgent = agent;
+      this.lastContext = context;
+      return typeof enrichment === 'function' ? enrichment(agent, context) : enrichment;
+    }
+
+    static getInstances() {
+      return instances;
+    }
+  };
+}
+
+describe('story context validation helper', () => {
+  it('approves when persona fragments and sections are present', async () => {
+    const projectState = createProjectState();
+    const enrichment = {
+      context: { story: { title: 'Sample Story' } },
+      personaFragments: ['Senior Frontend Engineer persona'],
+      contextSections: [
+        { title: 'Acceptance Criteria', body: '- passes validation' },
+        { title: 'Definition of Done', body: '- tests updated' },
+      ],
+    };
+
+    const FakeBridge = createBridgeClass(enrichment);
+
+    const result = await runStoryContextValidation({
+      projectState,
+      createLLMClient: async () => ({ lane: 'review' }),
+      BMADBridge: FakeBridge,
+      notes: 'smoke test',
+      trigger: 'unit_test',
+    });
+
+    expect(result.status).toBe('approve');
+    expect(result.checkpoint).toBe(STORY_CONTEXT_VALIDATION_CHECKPOINT);
+    expect(projectState.records).toHaveLength(1);
+    expect(projectState.records[0].status).toBe('approve');
+
+    const [instance] = FakeBridge.getInstances();
+    expect(instance.initialized).toBe(true);
+    expect(instance.loadedAgentId).toBe('dev');
+    expect(instance.lastContext.story).toBeDefined();
+  });
+
+  it('blocks when acceptance criteria are missing', async () => {
+    const projectState = createProjectState({
+      getDeliverable: jest.fn(() => ({ content: { title: 'Story Without AC' } })),
+    });
+    const enrichment = {
+      context: { story: { title: 'Story Without AC' } },
+      personaFragments: [],
+      contextSections: [{ title: 'Definition of Done', body: '- tests updated' }],
+    };
+    const FakeBridge = createBridgeClass(enrichment);
+
+    const result = await runStoryContextValidation({
+      projectState,
+      createLLMClient: async () => ({ lane: 'review' }),
+      BMADBridge: FakeBridge,
+    });
+
+    expect(result.status).toBe('block');
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        'Acceptance Criteria section missing from enriched context.',
+        'No persona fragments generated for developer lane.',
+      ]),
+    );
+    expect(projectState.records[0].status).toBe('block');
+  });
+
+  it('throws when ensureStoryContextReadyForDevelopment encounters block status', async () => {
+    const projectState = createProjectState({
+      getDeliverable: jest.fn(() => null),
+    });
+    const enrichment = {
+      context: {},
+      personaFragments: [],
+      contextSections: [],
+    };
+    const FakeBridge = createBridgeClass(enrichment);
+
+    await expect(
+      ensureStoryContextReadyForDevelopment({
+        projectState,
+        createLLMClient: async () => ({ lane: 'review' }),
+        BMADBridge: FakeBridge,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('Story context validation failed'),
+      validation: expect.objectContaining({ status: 'block' }),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a disposable story_context_validation checkpoint that re-runs enrichers before development and gates transitions when enabled
- expose configure_developer_lane and run_story_context_validation MCP tools and persist outcomes via ProjectState.recordReviewOutcome
- document the new checkpoint and cover it with dedicated unit tests

## Testing
- npm test -- story-context-validation

------
https://chatgpt.com/codex/tasks/task_e_68df58ff7be483269da74dba07774979