### PR TITLE
feat: configure opencode model defaults

### DIFF
--- a/test/fixtures/opencode/existing/opencode.jsonc
+++ b/test/fixtures/opencode/existing/opencode.jsonc
@@ -1,0 +1,16 @@
+{
+  // Existing OpenCode configuration fixture without explicit model
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["./custom/instructions.yaml"],
+  "agent": {
+    "custom": {
+      "prompt": "{file:./agents/custom.md}"
+    }
+  },
+  "fallbackModels": ["custom/provider-model"],
+  "command": {
+    "custom": {
+      "template": "{file:./tasks/custom.md}"
+    }
+  }
+}

--- a/test/opencode-setup.test.js
+++ b/test/opencode-setup.test.js
@@ -1,0 +1,66 @@
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('fs-extra');
+const cjson = require('comment-json');
+const ideSetup = require('../tools/installer/lib/ide-setup');
+
+const DEFAULT_MODEL = 'codex/gpt-4.1';
+const DEFAULT_FALLBACKS = ['anthropic/claude-3.5-sonnet', 'openai/gpt-4o-mini'];
+
+const preconfiguredSettings = {
+  opencode: { useAgentPrefix: false, useCommandPrefix: false },
+  selectedPackages: { includeCore: false, packs: [] },
+};
+
+async function setupFixture(projectName) {
+  const source = path.join(__dirname, 'fixtures', 'opencode', projectName);
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), `bmad-opencode-${projectName}-`));
+  await fs.copy(source, tmpDir);
+  return tmpDir;
+}
+
+describe('setupOpenCode model defaults', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates opencode.jsonc with default model entries for a fresh project', async () => {
+    const projectDir = await setupFixture('base');
+
+    try {
+      await ideSetup.setupOpenCode(projectDir, null, null, preconfiguredSettings);
+
+      const configPath = path.join(projectDir, 'opencode.jsonc');
+      expect(await fs.pathExists(configPath)).toBe(true);
+
+      const raw = await fs.readFile(configPath, 'utf8');
+      const parsed = cjson.parse(raw);
+
+      expect(parsed.model).toBe(DEFAULT_MODEL);
+      expect(parsed.fallbackModels).toEqual(DEFAULT_FALLBACKS);
+    } finally {
+      await fs.remove(projectDir);
+    }
+  });
+
+  it('merges default model settings into an existing configuration without overriding custom entries', async () => {
+    const projectDir = await setupFixture('existing');
+
+    try {
+      await ideSetup.setupOpenCode(projectDir, null, null, preconfiguredSettings);
+
+      const configPath = path.join(projectDir, 'opencode.jsonc');
+      const raw = await fs.readFile(configPath, 'utf8');
+      const parsed = cjson.parse(raw);
+
+      expect(parsed.model).toBe(DEFAULT_MODEL);
+      const instructions = [...(parsed.instructions || [])];
+      expect(instructions).toEqual(
+        expect.arrayContaining(['./custom/instructions.yaml', '.bmad-core/core-config.yaml']),
+      );
+      expect(parsed.fallbackModels).toEqual(['custom/provider-model', ...DEFAULT_FALLBACKS]);
+    } finally {
+      await fs.remove(projectDir);
+    }
+  });
+});

--- a/test/opencode-setup.test.js
+++ b/test/opencode-setup.test.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 const cjson = require('comment-json');
 const ideSetup = require('../tools/installer/lib/ide-setup');
 
+// These default values must match tools/installer/lib/ide-setup.js defaultModelSettings
 const DEFAULT_MODEL = 'codex/gpt-4.1';
 const DEFAULT_FALLBACKS = ['anthropic/claude-3.5-sonnet', 'openai/gpt-4o-mini'];
 
@@ -59,6 +60,62 @@ describe('setupOpenCode model defaults', () => {
         expect.arrayContaining(['./custom/instructions.yaml', '.bmad-core/core-config.yaml']),
       );
       expect(parsed.fallbackModels).toEqual(['custom/provider-model', ...DEFAULT_FALLBACKS]);
+    } finally {
+      await fs.remove(projectDir);
+    }
+  });
+
+  it('handles empty strings and case variations in existing fallbackModels', async () => {
+    const projectDir = await setupFixture('base');
+
+    try {
+      // Create a config with empty strings and case variations
+      const configPath = path.join(projectDir, 'opencode.jsonc');
+      const testConfig = {
+        fallbackModels: ['', 'Anthropic/CLAUDE-3.5-sonnet', 'custom/model', '   '],
+      };
+      await fs.writeFile(configPath, cjson.stringify(testConfig, null, 2));
+
+      await ideSetup.setupOpenCode(projectDir, null, null, preconfiguredSettings);
+
+      const raw = await fs.readFile(configPath, 'utf8');
+      const parsed = cjson.parse(raw);
+
+      // Should have model added
+      expect(parsed.model).toBe(DEFAULT_MODEL);
+
+      // Should preserve the original entries including empty strings (not filtered from original array)
+      // Should not duplicate 'anthropic/claude-3.5-sonnet' due to case-insensitive matching
+      // Should add 'openai/gpt-4o-mini' which wasn't present
+      expect(parsed.fallbackModels).toContain('Anthropic/CLAUDE-3.5-sonnet');
+      expect(parsed.fallbackModels).toContain('custom/model');
+      expect(parsed.fallbackModels).toContain('openai/gpt-4o-mini');
+      expect(parsed.fallbackModels).toHaveLength(6); // '', 'Anthropic/CLAUDE...', 'custom/model', '   ', 'openai/gpt-4o-mini'
+    } finally {
+      await fs.remove(projectDir);
+    }
+  });
+
+  it('handles empty model field by setting default', async () => {
+    const projectDir = await setupFixture('base');
+
+    try {
+      // Create a config with empty model
+      const configPath = path.join(projectDir, 'opencode.jsonc');
+      const testConfig = {
+        model: '   ',
+        fallbackModels: ['custom/fallback'],
+      };
+      await fs.writeFile(configPath, cjson.stringify(testConfig, null, 2));
+
+      await ideSetup.setupOpenCode(projectDir, null, null, preconfiguredSettings);
+
+      const raw = await fs.readFile(configPath, 'utf8');
+      const parsed = cjson.parse(raw);
+
+      // Empty/whitespace model should be replaced with default
+      expect(parsed.model).toBe(DEFAULT_MODEL);
+      expect(parsed.fallbackModels).toEqual(['custom/fallback', ...DEFAULT_FALLBACKS]);
     } finally {
       await fs.remove(projectDir);
     }

--- a/tools/installer/lib/ide-setup.js
+++ b/tools/installer/lib/ide-setup.js
@@ -230,13 +230,13 @@ class IdeSetup extends BaseIdeSetup {
         fallbackArray = [];
       }
 
+      // Build a case-insensitive set of existing fallback models (string values only)
       const seen = new Set();
       for (const value of fallbackArray) {
-        if (typeof value === 'string') {
+        if (typeof value === 'string' && value.trim().length > 0) {
           seen.add(value.toLowerCase());
-        } else if (value !== null && value !== undefined) {
-          seen.add(String(value).toLowerCase());
         }
+        // Skip non-string or empty values - they won't be considered for duplicate detection
       }
 
       for (const fallbackModel of defaultModelSettings.fallbackModels) {

--- a/tools/installer/lib/ide-setup.js
+++ b/tools/installer/lib/ide-setup.js
@@ -138,6 +138,11 @@ class IdeSetup extends BaseIdeSetup {
     // - If opencode.json or opencode.jsonc exists: only ensure instructions include .bmad-core/core-config.yaml
     // - If none exists: create minimal opencode.jsonc with $schema and instructions array including that file
 
+    const defaultModelSettings = {
+      model: 'codex/gpt-4.1',
+      fallbackModels: ['anthropic/claude-3.5-sonnet', 'openai/gpt-4o-mini'],
+    };
+
     const jsonPath = path.join(installDir, 'opencode.json');
     const jsoncPath = path.join(installDir, 'opencode.jsonc');
     const hasJson = await fileManager.pathExists(jsonPath);
@@ -204,6 +209,52 @@ class IdeSetup extends BaseIdeSetup {
       return obj;
     };
 
+    const mergeModelDefaults = (configObj) => {
+      const summary = { modelAdded: false, fallbackAdded: 0 };
+
+      const hasModel = typeof configObj.model === 'string' && configObj.model.trim().length > 0;
+      if (!hasModel) {
+        configObj.model = defaultModelSettings.model;
+        summary.modelAdded = true;
+      }
+
+      let fallbackArray;
+      if (Array.isArray(configObj.fallbackModels)) {
+        fallbackArray = configObj.fallbackModels;
+      } else if (
+        typeof configObj.fallbackModels === 'string' &&
+        configObj.fallbackModels.trim().length > 0
+      ) {
+        fallbackArray = [configObj.fallbackModels.trim()];
+      } else {
+        fallbackArray = [];
+      }
+
+      const seen = new Set();
+      for (const value of fallbackArray) {
+        if (typeof value === 'string') {
+          seen.add(value.toLowerCase());
+        } else if (value !== null && value !== undefined) {
+          seen.add(String(value).toLowerCase());
+        }
+      }
+
+      for (const fallbackModel of defaultModelSettings.fallbackModels) {
+        const key = fallbackModel.toLowerCase();
+        if (!seen.has(key)) {
+          fallbackArray.push(fallbackModel);
+          seen.add(key);
+          summary.fallbackAdded++;
+        }
+      }
+
+      if (!Array.isArray(configObj.fallbackModels)) {
+        configObj.fallbackModels = fallbackArray;
+      }
+
+      return summary;
+    };
+
     const mergeBmadAgentsAndCommands = async (configObj) => {
       // Ensure objects exist
       if (!configObj.agent || typeof configObj.agent !== 'object') configObj.agent = {};
@@ -221,6 +272,8 @@ class IdeSetup extends BaseIdeSetup {
         commandsAdded: 0,
         commandsUpdated: 0,
         commandsSkipped: 0,
+        modelAdded: false,
+        fallbackAdded: 0,
       };
 
       // Determine package scope: previously SELECTED packages in installer UI
@@ -556,6 +609,10 @@ class IdeSetup extends BaseIdeSetup {
         }
       }
 
+      const modelSummary = mergeModelDefaults(configObj);
+      summary.modelAdded = modelSummary.modelAdded;
+      summary.fallbackAdded = modelSummary.fallbackAdded;
+
       return { configObj, summary };
     };
 
@@ -569,6 +626,10 @@ class IdeSetup extends BaseIdeSetup {
         const agents = selectedAgent ? [selectedAgent] : await this.getAllAgentIds(installDir);
         const tasks = await this.getAllTaskIds(installDir);
 
+        const fallbackModelList = defaultModelSettings.fallbackModels
+          .map((model) => `\`${model}\``)
+          .join(', ');
+
         let section = '';
         section += `${startMarker}\n`;
         section += `# BMAD-METHOD Agents and Tasks (OpenCode)\n\n`;
@@ -577,7 +638,9 @@ class IdeSetup extends BaseIdeSetup {
         section += `- Run \`opencode\` in this project. OpenCode will read \`AGENTS.md\` and your OpenCode config (opencode.json[c]).\n`;
         section += `- Reference a role naturally, e.g., "As dev, implement ..." or use commands defined in your BMAD tasks.\n`;
         section += `- Commit \`.bmad-core\` and \`AGENTS.md\` if you want teammates to share the same configuration.\n`;
-        section += `- Refresh this section after BMAD updates: \`npx bmad-method install -f -i opencode\`.\n\n`;
+        section += `- Refresh this section after BMAD updates: \`npx bmad-method install -f -i opencode\`.\n`;
+        section += `- Default models: primary \`${defaultModelSettings.model}\` with fallbacks ${fallbackModelList}.\n`;
+        section += `- Toggle providers by editing \`model\`/\`fallbackModels\` in \`opencode.jsonc\` and rerunning the installer to merge other settings.\n\n`;
 
         section += `### Helpful Commands\n\n`;
         section += `- List agents: \`npx bmad-method list:agents\`\n`;
@@ -730,7 +793,7 @@ class IdeSetup extends BaseIdeSetup {
         // Summary output
         console.log(
           chalk.dim(
-            `  File: ${path.basename(targetPath)} | Agents +${summary.agentsAdded} ~${summary.agentsUpdated} ⨯${summary.agentsSkipped} | Commands +${summary.commandsAdded} ~${summary.commandsUpdated} ⨯${summary.commandsSkipped}`,
+            `  File: ${path.basename(targetPath)} | Agents +${summary.agentsAdded} ~${summary.agentsUpdated} ⨯${summary.agentsSkipped} | Commands +${summary.commandsAdded} ~${summary.commandsUpdated} ⨯${summary.commandsSkipped} | Model ${summary.modelAdded ? 'set' : 'kept'} | Fallbacks +${summary.fallbackAdded}`,
           ),
         );
         // Ensure AGENTS.md is created/updated for OpenCode as well
@@ -758,7 +821,7 @@ class IdeSetup extends BaseIdeSetup {
       );
       console.log(
         chalk.dim(
-          `  File: opencode.jsonc | Agents +${summary.agentsAdded} | Commands +${summary.commandsAdded}`,
+          `  File: opencode.jsonc | Agents +${summary.agentsAdded} | Commands +${summary.commandsAdded} | Model ${summary.modelAdded ? 'set' : 'kept'} | Fallbacks +${summary.fallbackAdded}`,
         ),
       );
       // Also create/update AGENTS.md for OpenCode on new-config path


### PR DESCRIPTION
## Summary
- add default Codex/Claude/OpenAI model configuration when provisioning OpenCode and merge it without clobbering existing settings
- document the default and toggle flow in the generated OpenCode AGENTS.md guidance
- add fixture-based Jest coverage for fresh and existing OpenCode configs

## Testing
- npm test -- opencode-setup

------
https://chatgpt.com/codex/tasks/task_e_68df66e9bc0883268817728c41c499fb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically applies default model and fallback models during OpenCode setup and merges, preserving existing settings.
  - Generates minimal opencode.jsonc with sensible defaults.
  - Enhanced setup notes reflecting current defaults.
- Documentation
  - AGENTS.md and generated sections now display default model and fallback lists.
- Tests
  - Added tests for fresh setup and merging existing configurations, validating model and fallback behavior and instructions preservation.
- Chores
  - Added OpenCode fixture with custom instructions and templates for existing config scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->