### PR TITLE
Add CLI provisioning checks for Codex and Claude launchers

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -209,6 +209,16 @@ When you include Codex CLI during installation, the wizard now also prepares you
 
 This step is skipped automatically in non-interactive environments. See [`codex-config.toml.example`](./codex-config.toml.example) for the full TOML structure you can tailor afterwards.
 
+### Automatic CLI Provisioning
+
+The `bin/bmad-codex` and `bin/bmad-chat` launchers now validate that the Codex and Claude CLIs are installed **before** spawning the orchestrator session. If a binary is missing, the script will:
+
+- Offer an interactive menu with installation helpers (for example `npm exec --yes @openai/codex-cli@latest -- codex --help`, Homebrew taps, and the official download docs).
+- Fall back to printing the same guidance when running in non-interactive contexts (CI, redirected stdin/stdout) so automation jobs fail fast but still surface the remediation steps.
+- Cache the resolved binary location in `.bmad-invisible/cli-state.json` once the CLI is detected so you are not prompted again on subsequent runs.
+
+Ensure your environment has network access and an up-to-date Node.js runtime so that `npm exec`-based installers can complete successfully. If you prefer manual installation, pick the documentation option from the prompt and follow the upstream instructions before re-running the launcher.
+
 ### Invisible Story Context Packets
 
 - When the orchestrator transitions into development or QA, it now assembles a just-in-time story packet inspired by V6’s `story-context` command.

--- a/bin/bmad-chat
+++ b/bin/bmad-chat
@@ -9,6 +9,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const { runIntegrityPreflight } = require('../common/utils/integrity');
+const { ensureCliBinary } = require('../common/utils/cli-provisioning');
 
 // Get paths
 const rootDir = path.join(__dirname, '..');
@@ -33,36 +34,70 @@ let orchestratorContent = fs.readFileSync(orchestratorPath, 'utf8');
 // Remove YAML frontmatter (everything between --- markers)
 orchestratorContent = orchestratorContent.replace(/^---\n[\s\S]*?\n---\n/, '');
 
-// Build Claude command
-const claudeArgs = [
-  '--mcp-config', mcpConfigPath,
-  '--append-system-prompt', orchestratorContent,
-];
+async function main() {
+  const claudeCheck = await ensureCliBinary({
+    rootDir,
+    binaryName: 'claude',
+    friendlyName: 'Claude Code CLI',
+    installGuide: {
+      autoInstallCommand:
+        'npm exec --yes @anthropic-ai/claude-code@latest -- claude --help',
+      manualSteps: [
+        {
+          label: 'Homebrew (macOS/Linux)',
+          command: 'brew install anthropic-ai/anthropic/claude',
+        },
+        {
+          label: 'Official installer & docs',
+          url: 'https://claude.ai/code',
+        },
+      ],
+    },
+  });
 
-// Add any additional args from user
-const userArgs = process.argv.slice(2);
-if (userArgs.length > 0) {
-  claudeArgs.push(...userArgs);
+  if (!claudeCheck.ok) {
+    process.exit(claudeCheck.exitCode ?? 1);
+  }
+
+  // Build Claude command
+  const claudeArgs = [
+    '--mcp-config', mcpConfigPath,
+    '--append-system-prompt', orchestratorContent,
+  ];
+
+  // Add any additional args from user
+  const userArgs = process.argv.slice(2);
+  if (userArgs.length > 0) {
+    claudeArgs.push(...userArgs);
+  }
+
+  console.log('🎯 Starting BMAD Invisible Orchestrator...');
+  console.log('📡 MCP Server: bmad-invisible-orchestrator');
+  console.log('🤖 Agent: Invisible BMAD Orchestrator');
+  console.log('💬 Type your project idea to begin!\n');
+
+  const claudeBinary = claudeCheck.binaryPath || 'claude';
+
+  // Launch Claude CLI
+  const claude = spawn(claudeBinary, claudeArgs, {
+    stdio: 'inherit',
+    shell: false, // Don't use shell to avoid parsing issues with multi-line content
+  });
+
+  claude.on('error', (error) => {
+    console.error('Error launching Claude CLI:', error.message);
+    console.error(
+      '\nClaude CLI is required. See https://claude.ai/code for installation instructions.'
+    );
+    process.exit(1);
+  });
+
+  claude.on('exit', (code) => {
+    process.exit(code || 0);
+  });
 }
 
-console.log('🎯 Starting BMAD Invisible Orchestrator...');
-console.log('📡 MCP Server: bmad-invisible-orchestrator');
-console.log('🤖 Agent: Invisible BMAD Orchestrator');
-console.log('💬 Type your project idea to begin!\n');
-
-// Launch Claude CLI
-const claude = spawn('claude', claudeArgs, {
-  stdio: 'inherit',
-  shell: false, // Don't use shell to avoid parsing issues with multi-line content
-});
-
-claude.on('error', (error) => {
-  console.error('Error launching Claude CLI:', error.message);
-  console.error('\nMake sure Claude CLI is installed and in your PATH');
-  console.error('Install: https://claude.ai/code');
+main().catch((error) => {
+  console.error('Unexpected error while starting Claude chat:', error);
   process.exit(1);
-});
-
-claude.on('exit', (code) => {
-  process.exit(code || 0);
 });

--- a/bin/bmad-codex
+++ b/bin/bmad-codex
@@ -9,6 +9,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const { runIntegrityPreflight } = require('../common/utils/integrity');
+const { ensureCliBinary } = require('../common/utils/cli-provisioning');
 
 // Get paths
 const rootDir = path.join(__dirname, '..');
@@ -40,35 +41,69 @@ if (userArgs.length > 0 && ['start', 'chat', 'run'].includes(userArgs[0])) {
   userArgs = userArgs.slice(1);
 }
 
-// Build Codex command
-const codexArgs = [
-  '--mcp-config',
-  mcpConfigPath,
-  '--append-system-prompt',
-  orchestratorContent,
-  ...userArgs,
-];
+async function main() {
+  const codexCheck = await ensureCliBinary({
+    rootDir,
+    binaryName: 'codex',
+    friendlyName: 'OpenAI Codex CLI',
+    installGuide: {
+      autoInstallCommand:
+        'npm exec --yes @openai/codex-cli@latest -- codex --help',
+      manualSteps: [
+        {
+          label: 'Homebrew (macOS/Linux)',
+          command: 'brew install openai/codex/codex',
+        },
+        {
+          label: 'Manual download & docs',
+          url: 'https://platform.openai.com/docs/guides/codex',
+        },
+      ],
+    },
+  });
 
-console.log('🎯 Starting BMAD Invisible Orchestrator with Codex...');
+  if (!codexCheck.ok) {
+    process.exit(codexCheck.exitCode ?? 1);
+  }
 
-console.log('📡 MCP Server: bmad-invisible-orchestrator');
-console.log('🤖 Agent: Invisible BMAD Orchestrator');
-console.log('💬 Type your project idea to begin!\n');
+  // Build Codex command
+  const codexArgs = [
+    '--mcp-config',
+    mcpConfigPath,
+    '--append-system-prompt',
+    orchestratorContent,
+    ...userArgs,
+  ];
 
-// Launch Codex CLI
-const codex = spawn('codex', codexArgs, {
-  stdio: 'inherit',
-  shell: false,
-});
+  console.log('🎯 Starting BMAD Invisible Orchestrator with Codex...');
 
-codex.on('error', (error) => {
-  console.error('Error launching Codex CLI:', error.message);
-  console.error('\nMake sure Codex CLI is installed and in your PATH');
-  console.error('Install: https://platform.openai.com/docs/guides/codex');
+  console.log('📡 MCP Server: bmad-invisible-orchestrator');
+  console.log('🤖 Agent: Invisible BMAD Orchestrator');
+  console.log('💬 Type your project idea to begin!\n');
 
+  const codexBinary = codexCheck.binaryPath || 'codex';
+
+  // Launch Codex CLI
+  const codex = spawn(codexBinary, codexArgs, {
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  codex.on('error', (error) => {
+    console.error('Error launching Codex CLI:', error.message);
+    console.error(
+      '\nCodex CLI is required. See https://platform.openai.com/docs/guides/codex for manual installation steps.'
+    );
+
+    process.exit(1);
+  });
+
+  codex.on('exit', (code) => {
+    process.exit(code || 0);
+  });
+}
+
+main().catch((error) => {
+  console.error('Unexpected error while starting Codex:', error);
   process.exit(1);
-});
-
-codex.on('exit', (code) => {
-  process.exit(code || 0);
 });

--- a/common/utils/cli-provisioning.js
+++ b/common/utils/cli-provisioning.js
@@ -1,0 +1,253 @@
+/* eslint-disable unicorn/prefer-module */
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync, spawn } = require('node:child_process');
+const readline = require('node:readline');
+
+function ensureStateDir(rootDir) {
+  const stateDir = path.join(rootDir, '.bmad-invisible');
+  if (!fs.existsSync(stateDir)) {
+    fs.mkdirSync(stateDir, { recursive: true });
+  }
+  return stateDir;
+}
+
+function getStateFile(rootDir) {
+  const dir = ensureStateDir(rootDir);
+  return path.join(dir, 'cli-state.json');
+}
+
+function loadState(rootDir) {
+  const stateFile = getStateFile(rootDir);
+  if (!fs.existsSync(stateFile)) {
+    return {};
+  }
+
+  try {
+    const raw = fs.readFileSync(stateFile, 'utf8');
+    return raw ? JSON.parse(raw) : {};
+  } catch (error) {
+    console.warn('Warning: unable to read CLI state cache:', error.message);
+    return {};
+  }
+}
+
+function saveState(rootDir, state) {
+  const stateFile = getStateFile(rootDir);
+  try {
+    fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+  } catch (error) {
+    console.warn('Warning: unable to persist CLI state cache:', error.message);
+  }
+}
+
+function findBinaryPath(binaryName) {
+  const command = process.platform === 'win32' ? 'where' : 'which';
+  const lookup = spawnSync(command, [binaryName], { stdio: 'pipe' });
+  if (lookup.status === 0) {
+    const output = lookup.stdout.toString().split(/\r?\n/).find(Boolean);
+    if (output) {
+      return output.trim();
+    }
+  }
+  return null;
+}
+
+function createInterface() {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+}
+
+function ask(question) {
+  return new Promise((resolve) => {
+    const rl = createInterface();
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+function printManualInstructions(friendlyName, manualSteps = []) {
+  if (manualSteps.length === 0) {
+    return;
+  }
+
+  console.log(`\nManual installation options for ${friendlyName}:`);
+  for (const step of manualSteps) {
+    const parts = [];
+    if (step.command) {
+      parts.push(step.command);
+    }
+    if (step.url) {
+      parts.push(step.url);
+    }
+    const suffix = parts.length > 0 ? `: ${parts.join(' | ')}` : '';
+    console.log(` - ${step.label}${suffix}`);
+    if (step.description) {
+      console.log(`   ${step.description}`);
+    }
+  }
+  console.log();
+}
+
+function nonInteractiveMode() {
+  return Boolean(
+    process.env.CI === 'true' ||
+      process.env.CI === '1' ||
+      !process.stdin.isTTY ||
+      !process.stdout.isTTY,
+  );
+}
+
+function buildOptions(installGuide) {
+  const options = [];
+  let index = 1;
+  if (installGuide.autoInstallCommand) {
+    options.push({
+      key: String(index++),
+      type: 'auto',
+      label: `Run "${installGuide.autoInstallCommand}" now`,
+    });
+  }
+
+  if (installGuide.manualSteps && installGuide.manualSteps.length > 0) {
+    options.push({
+      key: String(index++),
+      type: 'manual',
+      label: 'Show manual installation commands',
+    });
+  }
+
+  options.push({ key: String(index++), type: 'abort', label: 'Cancel and exit' });
+  return options;
+}
+
+function printOptions(options) {
+  console.log('\nInstallation options:');
+  for (const option of options) {
+    console.log(` ${option.key}) ${option.label}`);
+  }
+}
+
+function runShellCommand(command, cwd) {
+  return new Promise((resolve) => {
+    const child = spawn(command, {
+      cwd,
+      stdio: 'inherit',
+      shell: true,
+      env: process.env,
+    });
+
+    child.on('exit', (code) => {
+      resolve(code === 0);
+    });
+
+    child.on('error', () => {
+      resolve(false);
+    });
+  });
+}
+
+async function ensureCliBinary({ rootDir, binaryName, friendlyName, installGuide = {} }) {
+  const state = loadState(rootDir);
+  const now = new Date().toISOString();
+  const existingRecord = state[binaryName] || {};
+
+  const initialPath = findBinaryPath(binaryName);
+  if (initialPath) {
+    state[binaryName] = {
+      installed: true,
+      binaryPath: initialPath,
+      lastChecked: now,
+    };
+    saveState(rootDir, state);
+    return { ok: true, binaryPath: initialPath };
+  }
+
+  state[binaryName] = {
+    ...existingRecord,
+    installed: false,
+    lastPrompted: now,
+  };
+  saveState(rootDir, state);
+
+  console.error(`\n⚠️  ${friendlyName} (${binaryName}) is not available on your PATH.`);
+  if (existingRecord.installed && existingRecord.binaryPath) {
+    console.error(
+      `The previous installation recorded at ${existingRecord.binaryPath} is no longer reachable.`,
+    );
+  }
+
+  const manualSteps = installGuide.manualSteps || [];
+  if (nonInteractiveMode()) {
+    if (installGuide.autoInstallCommand) {
+      console.error(
+        `Run "${installGuide.autoInstallCommand}" to launch a local copy, or use one of the manual options below.`,
+      );
+    }
+    printManualInstructions(friendlyName, manualSteps);
+    return { ok: false, exitCode: 1 };
+  }
+
+  while (true) {
+    const options = buildOptions(installGuide);
+    printOptions(options);
+    const defaultOption = options.find((option) => option.type === 'manual') || options[0];
+    const answer = await ask(`Select an option [default: ${defaultOption.key}]: `);
+    const selectionKey = answer.trim() || defaultOption.key;
+    const selection = options.find((option) => option.key === selectionKey);
+
+    if (!selection) {
+      console.log('Unrecognised option. Please try again.');
+      continue;
+    }
+
+    if (selection.type === 'abort') {
+      return { ok: false, exitCode: 1 };
+    }
+
+    if (selection.type === 'auto') {
+      const success = await runShellCommand(
+        installGuide.autoInstallCommand,
+        installGuide.cwd || rootDir,
+      );
+      if (!success) {
+        const retry = await ask('Automatic installation failed. Try another option? (y/N) ');
+        if (retry.trim().toLowerCase() === 'y') {
+          continue;
+        }
+        return { ok: false, exitCode: 1 };
+      }
+    }
+
+    if (selection.type === 'manual') {
+      printManualInstructions(friendlyName, manualSteps);
+      const ready = await ask(
+        'Press Enter once installation is complete to retry detection, or type "skip" to cancel: ',
+      );
+      if (ready.trim().toLowerCase() === 'skip') {
+        return { ok: false, exitCode: 1 };
+      }
+    }
+
+    const resolvedPath = findBinaryPath(binaryName);
+    if (resolvedPath) {
+      state[binaryName] = {
+        installed: true,
+        binaryPath: resolvedPath,
+        lastChecked: new Date().toISOString(),
+      };
+      saveState(rootDir, state);
+      return { ok: true, binaryPath: resolvedPath };
+    }
+
+    console.error(`${friendlyName} is still not available. Let's try another option.\n`);
+  }
+}
+
+module.exports = {
+  ensureCliBinary,
+};

--- a/common/utils/cli-provisioning.js
+++ b/common/utils/cli-provisioning.js
@@ -15,19 +15,30 @@ function ensureStateDir(rootDir) {
       return stateDir;
     } catch (error) {
       // If rootDir is read-only (e.g., global npm install, CI artifact), fall back to user home
-      if (error.code === 'EACCES' || error.code === 'EROFS' || error.code === 'EPERM') {
+      if (
+        error.code === 'EACCES' ||
+        error.code === 'EROFS' ||
+        error.code === 'EPERM'
+      ) {
         const fallbackDir = path.join(os.homedir(), '.bmad-invisible');
         if (!fs.existsSync(fallbackDir)) {
           try {
             fs.mkdirSync(fallbackDir, { recursive: true });
-            console.warn(`Note: Using ${fallbackDir} for cache (installation directory is read-only)`);
+            console.warn(
+              `Note: Using ${fallbackDir} for cache (installation directory is read-only)`,
+            );
             return fallbackDir;
           } catch (fallbackError) {
-            console.warn('Warning: unable to create state directory:', fallbackError.message);
+            console.warn(
+              'Warning: unable to create state directory:',
+              fallbackError.message,
+            );
             return fallbackDir; // Return path anyway, saveState will handle write failures gracefully
           }
         }
-        console.warn(`Note: Using ${fallbackDir} for cache (installation directory is read-only)`);
+        console.warn(
+          `Note: Using ${fallbackDir} for cache (installation directory is read-only)`,
+        );
         return fallbackDir;
       }
       // For other errors, log and return the path anyway (saveState handles write failures)
@@ -124,7 +135,7 @@ function nonInteractiveMode() {
     process.env.CI === 'true' ||
       process.env.CI === '1' ||
       !process.stdin.isTTY ||
-      !process.stdout.isTTY,
+      !process.stdout.isTTY
   );
 }
 


### PR DESCRIPTION
## Summary
- add a shared CLI provisioning helper that checks for codex/claude binaries, guides installation, and caches state in .bmad-invisible
- update the Codex and Claude launchers to run the provisioning flow before spawning the underlying CLI
- document the automatic provisioning prompts and prerequisites in the usage guide

## Testing
- CI=1 node bin/bmad-codex --version
- CI=1 node bin/bmad-chat --version

------
https://chatgpt.com/codex/tasks/task_e_68df66df3dd883268dd867d917fd704d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic CLI provisioning for Codex and Claude: interactive installers, non-interactive fallbacks, cached binary locations, preflight checks, clearer startup logs, improved launch error handling, and correct exit behavior.

- Documentation
  - Added “Automatic CLI Provisioning” guidance (requirements, install options, caching, manual steps).
  - Expanded “Invisible Story Context Packets” with persona reminders, acceptance criteria, definitions of done, testing notes, runtime enricher hook, and link to related docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->