### PR TITLE
feat: prompt start command for assistant selection

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -46,7 +46,9 @@ npm install
 
 
 # Start chatting through your preferred CLI
-# (codex, chat, or opencode)
+# Codex: npm run codex
+# Claude: npm run bmad:chat
+# OpenCode: npx bmad-invisible opencode
 npm run codex
 
 ```

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -15,20 +15,20 @@ BMAD-Invisible provides a **natural conversational interface** that guides you t
 mkdir my-project && cd my-project
 ```
 
-Pick the assistant CLI you want and run the matching command:
+Pick your preferred assistant CLI when prompted (Codex is the default), or pass
+`--assistant=claude` / `--assistant=opencode` to skip the choice.
 
+```bash
 # Run this ONE command - it does everything!
-
 npx bmad-invisible@latest start
+```
 
-````
-
-Done! Either command automatically:
+Done! The command automatically:
 
 - Creates `package.json` if needed
 - Sets up project structure
 - Installs all dependencies
-- Launches the Codex-powered chat interface
+- Launches the selected chat interface
 
 > **💡 Tip**: Always use `@latest` to avoid npx cache issues on either flow!
 
@@ -45,10 +45,11 @@ npx bmad-invisible@latest init
 npm install
 
 
-# Start chatting through Codex
+# Start chatting through your preferred CLI
+# (codex, chat, or opencode)
 npm run codex
 
-````
+```
 
 ### Option 2: Global Installation
 
@@ -86,7 +87,7 @@ npm run codex
 
 ## Prerequisites
 
-You need **OpenAI Codex CLI** installed:
+You need at least one local chat CLI installed:
 
 ```bash
 # Check if installed
@@ -96,14 +97,9 @@ codex --version
 # https://platform.openai.com/docs/guides/codex
 ```
 
-### Codex CLI
-
-```bash
-# Check if installed
-codex --version
-
-# If not installed, follow the setup instructions in your Codex workspace
-```
+- OpenAI Codex CLI (`codex`)
+- Claude CLI (`claude`) – legacy support
+- OpenCode CLI (`opencode`)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ The orchestrator automatically selects the appropriate lane based on task comple
 - Node.js ≥ 20.0.0
 - npm ≥ 9.0.0
 
-- **OpenAI Codex CLI** (connects BMAD orchestrator to your local Codex workspace)
+- At least one chat CLI installed locally:
+  - **OpenAI Codex CLI**
+  - **Claude CLI**
+  - **OpenCode CLI**
 
 ### Installation
 
@@ -49,11 +52,14 @@ The orchestrator automatically selects the appropriate lane based on task comple
 npx bmad-invisible@latest start
 ```
 
+> Prefer a specific CLI? Append `--assistant=claude` or `--assistant=opencode` to skip the prompt.
+
 That's it! This command will:
 
 - Create project structure
 - Install all dependencies
-- Launch the Codex-powered chat interface
+- Prompt you to choose Codex, Claude, or OpenCode (defaults to Codex)
+- Launch the selected chat interface
 
 > **💡 Tip**: Always use `@latest` to ensure you get the newest version!
 
@@ -67,7 +73,8 @@ npx bmad-invisible@latest init
 npm install
 
 
-# Start chatting through Codex
+# Start chatting through your preferred CLI
+# (or use --assistant=claude / --assistant=opencode with `start`)
 npm run codex
 
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ npm install
 
 
 # Start chatting through your preferred CLI
-# (or use --assistant=claude / --assistant=opencode with `start`)
+# Codex: npm run codex
+# Claude: npm run bmad:chat
+# OpenCode: npx bmad-invisible opencode
 npm run codex
 
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -24,7 +24,10 @@ npx bmad-invisible@latest init
 # Install dependencies
 npm install
 
-# Start chatting (codex, chat, or opencode as desired)
+# Start chatting (pick your assistant)
+# Codex: npm run codex
+# Claude: npm run bmad:chat
+# OpenCode: npx bmad-invisible opencode
 npm run bmad:chat
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,6 +10,8 @@ npx bmad-invisible@latest start
 ```
 
 This does everything: creates structure, installs dependencies, and launches chat!
+You'll be prompted to pick Codex, Claude, or OpenCode (defaults to Codex). Use
+`--assistant=<choice>` to skip the prompt.
 
 > **💡 Tip**: Always use `@latest` to get the newest version!
 
@@ -22,7 +24,7 @@ npx bmad-invisible@latest init
 # Install dependencies
 npm install
 
-# Start chatting
+# Start chatting (codex, chat, or opencode as desired)
 npm run bmad:chat
 ```
 

--- a/bin/bmad-invisible
+++ b/bin/bmad-invisible
@@ -94,10 +94,24 @@ const parseAssistantFromArgs = (currentArgs) => {
 };
 
 const promptForAssistant = () =>
-  new Promise((resolve) => {
+  new Promise((resolve, reject) => {
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
+    });
+
+    // Ensure readline is cleaned up on error
+    const cleanup = () => {
+      try {
+        rl.close();
+      } catch {
+        // Ignore cleanup errors
+      }
+    };
+
+    rl.on('error', (error) => {
+      cleanup();
+      reject(error);
     });
 
     const options = ASSISTANT_CHOICES.map((choice) => {
@@ -110,7 +124,7 @@ const promptForAssistant = () =>
     rl.question(
       `Which assistant should we launch? (${options}): `,
       (answer) => {
-        rl.close();
+        cleanup();
         const normalized = (answer || '').trim().toLowerCase();
         if (!normalized) {
           resolve(DEFAULT_ASSISTANT);
@@ -363,11 +377,13 @@ For detailed documentation, visit:
     const child = spawn('opencode', args, {
       stdio: 'inherit',
       cwd: process.cwd(),
-      shell: true,
+      shell: false,
     });
 
     child.on('error', (error) => {
       console.error('❌ Failed to launch OpenCode CLI:', error.message);
+      console.error('   Make sure OpenCode is installed and in your PATH.');
+      console.error('   Visit: https://github.com/openchatai/opencode for installation instructions');
       process.exit(1);
     });
 
@@ -492,6 +508,9 @@ const run = (argv = process.argv) => {
   }
 };
 
+// Run integrity check only when executed directly (not when imported for testing)
+// This ensures the CLI validates package integrity at runtime while allowing
+// tests to import and mock functions without triggering validation
 if (require.main === module) {
   runIntegrityPreflight(packageRoot, { silentOnMatch: true });
 

--- a/bin/bmad-invisible
+++ b/bin/bmad-invisible
@@ -12,12 +12,12 @@
 const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const readline = require('readline');
 const { runIntegrityPreflight } = require('../common/utils/integrity');
 
-const [, , command, ...args] = process.argv;
+let command;
+let args = [];
 const packageRoot = path.join(__dirname, '..');
-
-runIntegrityPreflight(packageRoot, { silentOnMatch: true });
 
 // Get current package version
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
@@ -32,10 +32,11 @@ Usage:
 
 Commands:
 
-  start                🚀 ONE-COMMAND SETUP: init + install + codex (recommended!)
+  start                🚀 ONE-COMMAND SETUP: init + install + launch chat (Codex default)
   init                 Initialize BMAD-invisible in current project
   codex                Start conversational interface (requires Codex CLI)
   chat                 Start conversational interface with Claude CLI (legacy)
+  opencode             Start conversational interface with OpenCode CLI
 
   install              Install BMAD-invisible globally
   build                Build MCP server
@@ -46,6 +47,8 @@ Commands:
 Examples:
 
   npx bmad-invisible@latest start      # 🚀 Do everything in one command!
+  npx bmad-invisible@latest start --assistant=opencode
+                                      # Skip the prompt and launch OpenCode
   npx bmad-invisible@latest init       # Setup in current project
   npm run codex                        # Start conversation (after install)
 
@@ -57,16 +60,100 @@ For more information: https://github.com/bacoco/BMAD-invisible
 `);
 };
 
-// Show help if no command provided
-if (!command || command === '--help' || command === '-h') {
-  printHelp();
-  process.exit(0);
-}
+const ASSISTANT_CHOICES = ['codex', 'claude', 'opencode'];
+const DEFAULT_ASSISTANT = 'codex';
+
+const formatAssistantName = (value) =>
+  value.charAt(0).toUpperCase() + value.slice(1);
+
+const parseAssistantFromArgs = (currentArgs) => {
+  let assistant;
+  const sanitized = [];
+
+  for (let index = 0; index < currentArgs.length; index += 1) {
+    const arg = currentArgs[index];
+
+    if (arg === '--assistant') {
+      assistant = currentArgs[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--assistant=')) {
+      assistant = arg.split('=')[1];
+      continue;
+    }
+
+    sanitized.push(arg);
+  }
+
+  return {
+    assistant: assistant ? assistant.toLowerCase() : undefined,
+    sanitized,
+  };
+};
+
+const promptForAssistant = () =>
+  new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    const options = ASSISTANT_CHOICES.map((choice) => {
+      if (choice === DEFAULT_ASSISTANT) {
+        return `${formatAssistantName(choice)} (default)`;
+      }
+      return formatAssistantName(choice);
+    }).join(' / ');
+
+    rl.question(
+      `Which assistant should we launch? (${options}): `,
+      (answer) => {
+        rl.close();
+        const normalized = (answer || '').trim().toLowerCase();
+        if (!normalized) {
+          resolve(DEFAULT_ASSISTANT);
+          return;
+        }
+
+        if (ASSISTANT_CHOICES.includes(normalized)) {
+          resolve(normalized);
+          return;
+        }
+
+        console.log('⚠️ Unrecognized selection. Defaulting to Codex.');
+        resolve(DEFAULT_ASSISTANT);
+      },
+    );
+  });
+
+const determineAssistant = async (flagValue) => {
+  if (flagValue) {
+    if (ASSISTANT_CHOICES.includes(flagValue)) {
+      return flagValue;
+    }
+
+    console.log('⚠️ Unsupported assistant flag value. Defaulting to Codex.');
+    return DEFAULT_ASSISTANT;
+  }
+
+  if (!process.stdout.isTTY) {
+    return DEFAULT_ASSISTANT;
+  }
+
+  return promptForAssistant();
+};
 
 // Command handlers
 const commands = {
   start: async () => {
     console.log('🚀 Starting BMAD-invisible setup...\n');
+
+    // Determine assistant preference before installation begins
+    const { assistant: assistantFlag, sanitized } = parseAssistantFromArgs(args);
+    args.splice(0, args.length, ...sanitized);
+    const assistant = await determineAssistant(assistantFlag);
 
     // Run init
     await commands.init();
@@ -89,10 +176,20 @@ const commands = {
       });
     });
 
-    // Start Codex session
-    console.log('\n🎯 Starting BMAD Invisible Orchestrator with Codex...\n');
-    await commands.codex();
+    const assistantName = formatAssistantName(assistant);
+    console.log(`\n🎯 Starting BMAD Invisible Orchestrator with ${assistantName}...\n`);
 
+    if (assistant === 'claude') {
+      await commands.chat();
+      return;
+    }
+
+    if (assistant === 'opencode') {
+      await commands.opencode();
+      return;
+    }
+
+    await commands.codex();
   },
 
   init: async () => {
@@ -252,6 +349,23 @@ For detailed documentation, visit:
     });
   },
 
+  opencode: async () => {
+    const child = spawn('opencode', args, {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+      shell: true,
+    });
+
+    child.on('error', (error) => {
+      console.error('❌ Failed to launch OpenCode CLI:', error.message);
+      process.exit(1);
+    });
+
+    child.on('exit', (code) => {
+      process.exit(code || 0);
+    });
+  },
+
   install: async () => {
     console.log('📦 Installing BMAD-invisible globally...\n');
 
@@ -331,19 +445,58 @@ For detailed documentation, visit:
   },
 };
 
-// Execute command
-const handler = commands[command];
-if (!handler) {
-  console.error(`❌ Unknown command: ${command}`);
-  console.log('Run "npx bmad-invisible help" for usage information.');
-  process.exit(1);
-}
+const setRuntimeContext = (nextCommand, nextArgs = []) => {
+  command = nextCommand;
+  args = Array.isArray(nextArgs) ? [...nextArgs] : [];
+};
 
-// Handle both sync and async commands
-const result = handler();
-if (result && typeof result.catch === 'function') {
-  result.catch((error) => {
+const run = (argv = process.argv) => {
+  [, , command, ...args] = argv;
+
+  if (!command || command === '--help' || command === '-h') {
+    printHelp();
+    return Promise.resolve();
+  }
+
+  const handler = commands[command];
+  if (!handler) {
+    console.error(`❌ Unknown command: ${command}`);
+    console.log('Run "npx bmad-invisible help" for usage information.');
+    process.exit(1);
+  }
+
+  try {
+    const result = handler();
+    if (result && typeof result.then === 'function') {
+      return result.catch((error) => {
+        console.error('❌ Error:', error.message);
+        process.exit(1);
+      });
+    }
+
+    return Promise.resolve(result);
+  } catch (error) {
+    console.error('❌ Error:', error.message);
+    process.exit(1);
+    return Promise.resolve();
+  }
+};
+
+if (require.main === module) {
+  runIntegrityPreflight(packageRoot, { silentOnMatch: true });
+
+  run().catch((error) => {
     console.error('❌ Error:', error.message);
     process.exit(1);
   });
 }
+
+module.exports = {
+  commands,
+  determineAssistant,
+  parseAssistantFromArgs,
+  printHelp,
+  run,
+  runIntegrityPreflight,
+  setRuntimeContext,
+};

--- a/bin/bmad-invisible
+++ b/bin/bmad-invisible
@@ -321,6 +321,11 @@ For detailed documentation, visit:
       cwd: process.cwd(),
     });
 
+    child.on('error', (error) => {
+      console.error('❌ Failed to launch Codex CLI:', error.message);
+      process.exit(1);
+    });
+
     child.on('exit', (code) => {
       process.exit(code || 0);
     });
@@ -342,6 +347,11 @@ For detailed documentation, visit:
     const child = spawn('node', [chatScript, ...args], {
       stdio: 'inherit',
       cwd: process.cwd(),
+    });
+
+    child.on('error', (error) => {
+      console.error('❌ Failed to launch Claude CLI:', error.message);
+      process.exit(1);
     });
 
     child.on('exit', (code) => {

--- a/test/bmad-invisible-cli.test.js
+++ b/test/bmad-invisible-cli.test.js
@@ -1,0 +1,77 @@
+const path = require('node:path');
+
+const mockSpawn = jest.fn();
+
+jest.mock('child_process', () => ({
+  spawn: (...args) => mockSpawn(...args),
+}));
+
+const cli = require('../bin/bmad-invisible');
+
+const fs = require('node:fs');
+
+describe('bmad-invisible start assistant selection', () => {
+  const originalInit = cli.commands.init;
+  let exitSpy;
+  let existsSpy;
+  let originalIsTTY;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    mockSpawn.mockImplementation(() => ({
+      on: jest.fn((event, handler) => {
+        if (event === 'exit') {
+          handler(0);
+        }
+        return;
+      }),
+    }));
+
+    cli.commands.init = jest.fn().mockResolvedValue();
+    existsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    originalIsTTY = process.stdout.isTTY;
+  });
+
+  afterEach(() => {
+    cli.commands.init = originalInit;
+    existsSpy.mockRestore();
+    exitSpy.mockRestore();
+    process.stdout.isTTY = originalIsTTY;
+  });
+
+  test('defaults to Codex when no assistant flag is provided', async () => {
+    process.stdout.isTTY = false;
+    cli.setRuntimeContext('start', []);
+
+    await cli.commands.start();
+
+    expect(mockSpawn).toHaveBeenCalled();
+    const lastCall = mockSpawn.mock.calls.at(-1);
+    expect(lastCall[0]).toBe('node');
+    expect(lastCall[1][0]).toContain(path.join('bin', 'bmad-codex'));
+    expect(lastCall[1].some((arg) => arg.includes('--assistant'))).toBe(false);
+  });
+
+  test('launches Claude chat when requested via flag', async () => {
+    cli.setRuntimeContext('start', ['--assistant=claude']);
+
+    await cli.commands.start();
+
+    const lastCall = mockSpawn.mock.calls.at(-1);
+    expect(lastCall[0]).toBe('node');
+    expect(lastCall[1][0]).toContain(path.join('bin', 'bmad-chat'));
+    expect(lastCall[1].some((arg) => arg.includes('--assistant'))).toBe(false);
+  });
+
+  test('launches OpenCode when requested via flag', async () => {
+    cli.setRuntimeContext('start', ['--assistant=opencode']);
+
+    await cli.commands.start();
+
+    const lastCall = mockSpawn.mock.calls.at(-1);
+    expect(lastCall[0]).toBe('opencode');
+    expect(lastCall[1]).toEqual([]);
+    expect(lastCall[2].shell).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- prompt the `start` command to choose Codex, Claude, or OpenCode before launching and add an OpenCode helper
- document the new assistant selection flow in the README, Quickstart, and Usage guides
- add Jest coverage that stubs `spawn` to confirm each assistant option launches the right binary

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df66d8b17483269344d586a9790ef6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Interactive assistant selection when starting the CLI, with default to Codex and support for --assistant=claude or --assistant=opencode.
  - Improved start flow with clearer help, prompts, and standardized error handling.

- Documentation
  - Quickstart, README, and Usage updated to reflect multiple chat CLIs, selection prompts, and --assistant flag examples.
  - Prerequisites reframed to require at least one local chat CLI.

- Tests
  - Added unit tests covering start flow and launching behavior for Codex, Claude, and OpenCode selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->