### PR TITLE
Add operation policy enforcement for Codex

### DIFF
--- a/docs/codex-policy.example.yaml
+++ b/docs/codex-policy.example.yaml
@@ -1,0 +1,32 @@
+# Example Codex MCP policy configuration.
+#
+# Provide the file path via CODEX_POLICY_PATH (or CODEX_POLICY_FILE) to enable
+# policy enforcement. Keys are matched against normalized operation names and
+# optional metadata derived from the MCP runtime. When a policy specifies both a
+# base operation (e.g. "generate_deliverable") and a lane-specific override
+# (e.g. "generate_deliverable@review"), the more specific entry wins.
+#
+# Supported fields per entry:
+# - maxExecutionsPerHour: Limits how frequently the operation can run inside a
+#   rolling one hour window. The counter resets automatically every hour.
+# - escalate: Marks the operation as requiring manual approval. The Codex server
+#   blocks execution unless the normalized key is present in
+#   CODEX_APPROVED_OPERATIONS.
+#
+# The optional `defaults` section applies when no explicit key matches.
+defaults:
+  maxExecutionsPerHour: 60
+
+operations:
+  execute_auto_command:
+    maxExecutionsPerHour: 15
+
+  run_review_checkpoint:
+    maxExecutionsPerHour: 4
+    escalate: true
+
+  generate_deliverable@review:
+    escalate: true
+
+  save_deliverable: # Prevent storage storms without a hard block.
+    maxExecutionsPerHour: 20

--- a/src/mcp-server/codex-server.ts
+++ b/src/mcp-server/codex-server.ts
@@ -214,7 +214,8 @@ export class CodexClient {
       try {
         policyEnforcer = OperationPolicyEnforcer.fromFile(policyPath);
       } catch (error) {
-        console.error(`[Codex] Failed to load policy configuration from ${policyPath}:`, error);
+        console.error(`[Codex] FATAL: Failed to load policy from ${policyPath}:`, error);
+        console.error('[Codex] Server will run WITHOUT policy enforcement');
       }
     }
 

--- a/src/mcp-server/operation-policy.ts
+++ b/src/mcp-server/operation-policy.ts
@@ -161,7 +161,9 @@ export class OperationPolicyEnforcer {
     }
 
     if (this.config.defaults) {
-      return { key: "defaults", policy: this.config.defaults };
+      // Use the base operation name as the key so each operation has its own quota bucket
+      const baseKey = searchKeys.length > 0 ? searchKeys[searchKeys.length - 1] : "defaults";
+      return { key: baseKey, policy: this.config.defaults };
     }
 
     return undefined;

--- a/src/mcp-server/operation-policy.ts
+++ b/src/mcp-server/operation-policy.ts
@@ -1,0 +1,267 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { load as loadYaml } from "js-yaml";
+
+export interface OperationPolicy {
+  maxExecutionsPerHour?: number;
+  escalate?: boolean;
+}
+
+export interface PolicyConfig {
+  defaults?: OperationPolicy;
+  default?: OperationPolicy;
+  operations?: Record<string, OperationPolicy>;
+}
+
+interface NormalizedPolicyConfig {
+  defaults?: OperationPolicy;
+  operations: Record<string, OperationPolicy>;
+}
+
+interface UsageWindow {
+  count: number;
+  windowStart: number;
+}
+
+export interface PolicyAssessment {
+  matchedKey?: string;
+  requiresEscalation: boolean;
+  violation?: Error;
+  commit?: () => void;
+}
+
+interface EnforcerOptions {
+  now?: () => number;
+  source?: string;
+}
+
+const HOUR_IN_MS = 60 * 60 * 1000;
+
+export class OperationPolicyEnforcer {
+  private readonly config: NormalizedPolicyConfig;
+  private readonly usage: Map<string, UsageWindow> = new Map();
+  private readonly now: () => number;
+  private readonly source?: string;
+
+  constructor(config: PolicyConfig, options: EnforcerOptions = {}) {
+    this.config = normalizeConfig(config);
+    this.now = options.now ?? (() => Date.now());
+    this.source = options.source;
+  }
+
+  static fromFile(filePath: string): OperationPolicyEnforcer {
+    const absolutePath = path.resolve(filePath);
+    const raw = readFileSync(absolutePath, "utf8");
+    const parsed = loadYaml(raw);
+
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(
+        `[Codex] Policy file "${absolutePath}" must contain a YAML or JSON object at the top level.`
+      );
+    }
+
+    return new OperationPolicyEnforcer(parsed as PolicyConfig, { source: absolutePath });
+  }
+
+  assess(operation: string, keys: string[]): PolicyAssessment | undefined {
+    const resolved = this.resolve(keys);
+
+    if (!resolved) {
+      return undefined;
+    }
+
+    const { key, policy } = resolved;
+    const limit = policy.maxExecutionsPerHour;
+    const requiresEscalation = Boolean(policy.escalate);
+
+    if (limit != null) {
+      if (limit <= 0) {
+        const error = new Error(
+          `[Codex] Operation "${operation}" blocked by policy rule "${key}". This operation is disabled (maxExecutionsPerHour=0).`
+        );
+        error.name = "OperationPolicyError";
+
+        return {
+          matchedKey: key,
+          requiresEscalation,
+          violation: error,
+        };
+      }
+
+      const now = this.now();
+      const state = this.usage.get(key);
+      const withinWindow = Boolean(state && now - state.windowStart < HOUR_IN_MS);
+      const usedCount = withinWindow && state ? state.count : 0;
+
+      if (usedCount >= limit) {
+        const windowEndsAt = withinWindow && state ? state.windowStart + HOUR_IN_MS : now + HOUR_IN_MS;
+        const waitMs = Math.max(0, windowEndsAt - now);
+        const waitDescription = formatDuration(waitMs);
+        const error = new Error(
+          `[Codex] Operation "${operation}" blocked by policy rule "${key}". Limit of ${limit} executions per hour exceeded. Retry in ${waitDescription}.`
+        );
+        error.name = "OperationPolicyError";
+
+        return {
+          matchedKey: key,
+          requiresEscalation,
+          violation: error,
+        };
+      }
+
+      return {
+        matchedKey: key,
+        requiresEscalation,
+        commit: () => {
+          const commitNow = this.now();
+          const current = this.usage.get(key);
+
+          if (!current || commitNow - current.windowStart >= HOUR_IN_MS) {
+            this.usage.set(key, { windowStart: commitNow, count: 1 });
+          } else {
+            current.count += 1;
+          }
+        },
+      };
+    }
+
+    return {
+      matchedKey: key,
+      requiresEscalation,
+      commit: undefined,
+    };
+  }
+
+  getSource(): string | undefined {
+    return this.source;
+  }
+
+  private resolve(keys: string[]): { key: string; policy: OperationPolicy } | undefined {
+    const searchKeys = Array.from(new Set(keys.map((key) => key.toLowerCase()))).reverse();
+
+    for (const key of searchKeys) {
+      const policy = this.config.operations[key];
+      if (policy) {
+        return { key, policy };
+      }
+    }
+
+    const wildcard = this.config.operations["*"];
+    if (wildcard) {
+      return { key: "*", policy: wildcard };
+    }
+
+    if (this.config.defaults) {
+      return { key: "defaults", policy: this.config.defaults };
+    }
+
+    return undefined;
+  }
+}
+
+function normalizeConfig(input: PolicyConfig): NormalizedPolicyConfig {
+  const operations: Record<string, OperationPolicy> = {};
+  const defaultsRaw = input.defaults ?? input.default;
+  const operationsInput = input.operations as Record<string, unknown> | undefined;
+
+  if (operationsInput != null) {
+    if (typeof operationsInput !== "object" || Array.isArray(operationsInput)) {
+      throw new Error('[Codex] "operations" must be an object keyed by normalized operation name.');
+    }
+
+    for (const [rawKey, value] of Object.entries(operationsInput)) {
+      const key = rawKey.trim().toLowerCase();
+      if (key.length === 0) {
+        continue;
+      }
+
+      operations[key] = normalizePolicyEntry(value, `operations.${rawKey}`);
+    }
+  }
+
+  const defaults = defaultsRaw ? normalizePolicyEntry(defaultsRaw, "defaults") : undefined;
+
+  return { operations, defaults };
+}
+
+function normalizePolicyEntry(value: unknown, context: string): OperationPolicy {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`[Codex] Policy entry "${context}" must be an object.`);
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const normalized: OperationPolicy = {};
+
+  if ("maxExecutionsPerHour" in candidate && candidate.maxExecutionsPerHour != null) {
+    const rawLimit = candidate.maxExecutionsPerHour;
+    const parsedLimit = parseInteger(rawLimit);
+
+    if (parsedLimit < 0) {
+      throw new Error(
+        `[Codex] Policy entry "${context}.maxExecutionsPerHour" cannot be negative (received ${rawLimit}).`
+      );
+    }
+
+    normalized.maxExecutionsPerHour = parsedLimit;
+  }
+
+  if ("escalate" in candidate && candidate.escalate != null) {
+    const rawEscalate = candidate.escalate;
+    normalized.escalate = parseBoolean(rawEscalate);
+  }
+
+  return normalized;
+}
+
+function parseInteger(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  throw new Error(`[Codex] Expected a numeric value, received ${JSON.stringify(value)}.`);
+}
+
+function parseBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["1", "true", "yes", "on"].includes(normalized)) {
+      return true;
+    }
+
+    if (["0", "false", "no", "off"].includes(normalized)) {
+      return false;
+    }
+  }
+
+  throw new Error(`[Codex] Expected a boolean value, received ${JSON.stringify(value)}.`);
+}
+
+function formatDuration(ms: number): string {
+  if (ms <= 0) {
+    return "0 minutes";
+  }
+
+  const seconds = Math.ceil(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  }
+
+  const minutes = Math.ceil(ms / 60000);
+  if (minutes < 60) {
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+
+  const hours = Math.ceil(ms / 3600000);
+  return `${hours} hour${hours === 1 ? "" : "s"}`;
+}

--- a/src/mcp-server/types/js-yaml.d.ts
+++ b/src/mcp-server/types/js-yaml.d.ts
@@ -1,0 +1,3 @@
+declare module "js-yaml" {
+  export function load(source: string, options?: unknown): unknown;
+}

--- a/test/codex-policy.test.js
+++ b/test/codex-policy.test.js
@@ -1,0 +1,124 @@
+const fs = require('fs-extra');
+const os = require('node:os');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const repoRoot = path.join(__dirname, '..');
+
+function ensureBuildArtifacts() {
+  const artifactPath = path.join(repoRoot, 'dist', 'codex', 'codex-server.js');
+  if (!fs.existsSync(artifactPath)) {
+    execSync('npm run build:mcp', { cwd: repoRoot, stdio: 'inherit' });
+  }
+}
+
+ensureBuildArtifacts();
+
+const { CodexClient } = require(path.join(repoRoot, 'dist', 'codex', 'codex-server.js'));
+const { OperationPolicyEnforcer } = require(
+  path.join(repoRoot, 'dist', 'codex', 'operation-policy.js'),
+);
+
+const routerStub = {
+  resolve() {
+    return { provider: 'stub', model: 'stub' };
+  },
+  describe() {
+    return 'stub-route';
+  },
+};
+
+describe('Codex operation policy enforcement', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('allows compliant usage within per-hour limits', async () => {
+    const enforcer = new OperationPolicyEnforcer({
+      operations: {
+        deploy_release: { maxExecutionsPerHour: 2 },
+      },
+    });
+
+    const client = new CodexClient(routerStub, false, false, new Set(), enforcer);
+
+    await expect(client.ensureOperationAllowed('deploy_release')).resolves.toBeUndefined();
+    await expect(client.ensureOperationAllowed('deploy_release')).resolves.toBeUndefined();
+  });
+
+  test('blocks operations that exceed their quota with descriptive errors', async () => {
+    const enforcer = new OperationPolicyEnforcer({
+      operations: {
+        deploy_release: { maxExecutionsPerHour: 2 },
+      },
+    });
+
+    const client = new CodexClient(routerStub, false, false, new Set(), enforcer);
+
+    await client.ensureOperationAllowed('deploy_release');
+    await client.ensureOperationAllowed('deploy_release');
+
+    await expect(client.ensureOperationAllowed('deploy_release')).rejects.toThrow(
+      /limit of 2 executions per hour exceeded/i,
+    );
+  });
+
+  test('enforces escalation requirements until approval is granted', async () => {
+    const approvals = new Set();
+    const enforcer = new OperationPolicyEnforcer({
+      operations: {
+        run_review_checkpoint: { escalate: true },
+      },
+    });
+
+    const client = new CodexClient(routerStub, false, false, approvals, enforcer);
+
+    await expect(client.ensureOperationAllowed('run_review_checkpoint')).rejects.toThrow(
+      /requires escalation/i,
+    );
+
+    approvals.add('run_review_checkpoint');
+    await expect(client.ensureOperationAllowed('run_review_checkpoint')).resolves.toBeUndefined();
+  });
+
+  test('loads policies from environment-specified YAML files', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-policy-'));
+    const policyPath = path.join(tempDir, 'policy.yaml');
+
+    await fs.writeFile(
+      policyPath,
+      ['operations:', '  execute_auto_command:', '    maxExecutionsPerHour: 1'].join('\n'),
+    );
+
+    const originalEnv = {
+      CODEX_POLICY_PATH: process.env.CODEX_POLICY_PATH,
+      CODEX_POLICY_FILE: process.env.CODEX_POLICY_FILE,
+      CODEX_APPROVAL_MODE: process.env.CODEX_APPROVAL_MODE,
+      CODEX_AUTO_APPROVE: process.env.CODEX_AUTO_APPROVE,
+      CODEX_APPROVED_OPERATIONS: process.env.CODEX_APPROVED_OPERATIONS,
+    };
+
+    process.env.CODEX_POLICY_PATH = policyPath;
+    process.env.CODEX_POLICY_FILE = '';
+    process.env.CODEX_APPROVAL_MODE = 'false';
+    process.env.CODEX_AUTO_APPROVE = 'false';
+    process.env.CODEX_APPROVED_OPERATIONS = '';
+
+    try {
+      const client = CodexClient.fromEnvironment();
+
+      await client.ensureOperationAllowed('execute_auto_command');
+      await expect(client.ensureOperationAllowed('execute_auto_command')).rejects.toThrow(
+        /limit of 1 executions per hour exceeded/i,
+      );
+    } finally {
+      process.env.CODEX_POLICY_PATH = originalEnv.CODEX_POLICY_PATH;
+      process.env.CODEX_POLICY_FILE = originalEnv.CODEX_POLICY_FILE;
+      process.env.CODEX_APPROVAL_MODE = originalEnv.CODEX_APPROVAL_MODE;
+      process.env.CODEX_AUTO_APPROVE = originalEnv.CODEX_AUTO_APPROVE;
+      process.env.CODEX_APPROVED_OPERATIONS = originalEnv.CODEX_APPROVED_OPERATIONS;
+
+      await fs.remove(tempDir);
+    }
+  });
+});

--- a/test/codex-policy.test.js
+++ b/test/codex-policy.test.js
@@ -81,8 +81,17 @@ describe('Codex operation policy enforcement', () => {
     await expect(client.ensureOperationAllowed('run_review_checkpoint')).resolves.toBeUndefined();
   });
 
+  let tempDir;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.remove(tempDir);
+      tempDir = undefined;
+    }
+  });
+
   test('loads policies from environment-specified YAML files', async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-policy-'));
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-policy-'));
     const policyPath = path.join(tempDir, 'policy.yaml');
 
     await fs.writeFile(
@@ -117,8 +126,6 @@ describe('Codex operation policy enforcement', () => {
       process.env.CODEX_APPROVAL_MODE = originalEnv.CODEX_APPROVAL_MODE;
       process.env.CODEX_AUTO_APPROVE = originalEnv.CODEX_AUTO_APPROVE;
       process.env.CODEX_APPROVED_OPERATIONS = originalEnv.CODEX_APPROVED_OPERATIONS;
-
-      await fs.remove(tempDir);
     }
   });
 });


### PR DESCRIPTION
## Summary
- load optional Codex operation policy files supporting quotas and escalations
- enforce limits and escalation requirements inside CodexClient approval checks
- document policy schema and cover compliant, quota, and escalation scenarios with tests

## Testing
- npm test -- codex-policy.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df72beb8f4832685657a3d74b7e6fb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configurable operation policy enforcement with per-operation hourly limits, escalation/approval gating, and policy-aware client behavior.

- **Documentation**
  - Added an example policy file demonstrating defaults, wildcards, lane-specific overrides, and recommended safeguards.

- **Tests**
  - Integration tests for quotas, escalation/approval flow, and environment-driven policy loading.

- **Refactor**
  - Safer startup using a standard entry-point guard.

- **Chores**
  - Added YAML typings and test/build conveniences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->