### PR TITLE
feat: add structured logging to codex MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,9 +524,35 @@ autostart = true
   # Optional: override LLM routing per lane
   CODEX_QUICK_MODEL = "gpt-4.1-mini"
   CODEX_COMPLEX_MODEL = "claude-3-5-sonnet-20241022"
+  # Observability knobs (JSON logs + optional metrics)
+  CODEX_LOG_CONTEXT = '{"environment":"local"}'
+  CODEX_METRICS_STDOUT = "true"
 ```
 
 Refer to [`codex-config.toml.example`](codex-config.toml.example) for a ready-to-copy snippet and additional options.
+
+#### Observability & metrics
+
+- **Structured JSON logs** — The MCP server and Codex bridge now emit newline-delimited JSON to `stderr`. Every entry contains the event `msg`, timestamp, and metadata such as `lane`, `confidence`, `operation`, and measured `durationMs` so you can trace lane selection, approvals, and tool execution.
+- **Context enrichment** — Provide a JSON blob via `CODEX_LOG_CONTEXT` to stamp shared fields (e.g., `environment`, `cluster`, `team`) onto every log entry without code changes.
+- **Lightweight metrics** — Set `CODEX_METRICS_STDOUT=1` to mirror timing metrics (lane selection, workflow durations, tool runtimes) to `stdout` as JSON events. The helper supports adding additional sinks if you need to forward metrics to a collector.
+
+Example log line:
+
+```json
+{
+  "ts": "2024-07-16T12:34:56.789Z",
+  "level": "info",
+  "msg": "lane_selection_completed",
+  "service": "bmad-codex",
+  "component": "mcp-orchestrator",
+  "operation": "execute_workflow",
+  "lane": "quick",
+  "confidence": 0.88,
+  "durationMs": 142.3,
+  "environment": "local"
+}
+```
 
 ## 📚 Documentation
 

--- a/src/mcp-server/observability.ts
+++ b/src/mcp-server/observability.ts
@@ -1,0 +1,300 @@
+import { Writable } from "node:stream";
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+type Primitive = string | number | boolean | null;
+
+type FieldValue = Primitive | Primitive[] | Record<string, Primitive | Primitive[]>;
+
+export interface MetricEvent {
+  name: string;
+  value: number;
+  type?: "counter" | "gauge" | "timing";
+  unit?: string;
+  attributes?: Record<string, Primitive>;
+}
+
+export type MetricsSink = (event: MetricEvent) => void | Promise<void>;
+
+export interface StructuredLoggerOptions {
+  name?: string;
+  stream?: Writable;
+  base?: Record<string, FieldValue>;
+  metrics?: MetricsSink | MetricsSink[];
+}
+
+const DEFAULT_STREAM = process.stderr as Writable;
+
+function normalizeFields(fields?: Record<string, unknown>): Record<string, FieldValue> {
+  if (!fields) {
+    return {};
+  }
+
+  const normalized: Record<string, FieldValue> = {};
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (value == null) {
+      normalized[key] = null;
+      continue;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      normalized[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      normalized[key] = value
+        .map((item) => {
+          if (item == null) {
+            return null;
+          }
+
+          if (
+            typeof item === "string" ||
+            typeof item === "number" ||
+            typeof item === "boolean"
+          ) {
+            return item;
+          }
+
+          return JSON.stringify(item);
+        })
+        .filter((item) => item !== undefined) as Primitive[];
+      continue;
+    }
+
+    if (typeof value === "object") {
+      const objectValue = value as Record<string, unknown>;
+      const nested: Record<string, Primitive | Primitive[]> = {};
+
+      for (const [nestedKey, nestedValue] of Object.entries(objectValue)) {
+        if (nestedValue == null) {
+          nested[nestedKey] = null;
+        } else if (
+          typeof nestedValue === "string" ||
+          typeof nestedValue === "number" ||
+          typeof nestedValue === "boolean"
+        ) {
+          nested[nestedKey] = nestedValue;
+        } else if (Array.isArray(nestedValue)) {
+          nested[nestedKey] = nestedValue
+            .map((item) => {
+              if (item == null) {
+                return null;
+              }
+
+              if (
+                typeof item === "string" ||
+                typeof item === "number" ||
+                typeof item === "boolean"
+              ) {
+                return item;
+              }
+
+              return JSON.stringify(item);
+            })
+            .filter((item) => item !== undefined) as Primitive[];
+        } else {
+          nested[nestedKey] = JSON.stringify(nestedValue);
+        }
+      }
+
+      normalized[key] = nested;
+      continue;
+    }
+
+    normalized[key] = JSON.stringify(value);
+  }
+
+  return normalized;
+}
+
+function toMetricAttributes(
+  fields?: Record<string, unknown>
+): Record<string, Primitive> | undefined {
+  if (!fields) {
+    return undefined;
+  }
+
+  const attributes: Record<string, Primitive> = {};
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (value == null) {
+      attributes[key] = null;
+      continue;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      attributes[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      attributes[key] = value
+        .map((item) => {
+          if (item == null) {
+            return null;
+          }
+
+          if (
+            typeof item === "string" ||
+            typeof item === "number" ||
+            typeof item === "boolean"
+          ) {
+            return item;
+          }
+
+          return JSON.stringify(item);
+        })
+        .join(",");
+      continue;
+    }
+
+    if (typeof value === "object") {
+      attributes[key] = JSON.stringify(value);
+      continue;
+    }
+
+    attributes[key] = String(value);
+  }
+
+  return attributes;
+}
+
+function toMetricsArray(metrics?: MetricsSink | MetricsSink[]): MetricsSink[] {
+  if (!metrics) {
+    return [];
+  }
+
+  return Array.isArray(metrics) ? metrics : [metrics];
+}
+
+export class StructuredLogger {
+  private readonly stream: Writable;
+  private readonly base: Record<string, FieldValue>;
+  private readonly metricsSinks: MetricsSink[];
+
+  constructor(options: StructuredLoggerOptions = {}) {
+    this.stream = options.stream ?? DEFAULT_STREAM;
+    this.base = options.base ? { ...normalizeFields(options.base) } : {};
+    this.metricsSinks = toMetricsArray(options.metrics);
+
+    if (options.name && !this.base.service) {
+      this.base.service = options.name;
+    }
+  }
+
+  child(fields: Record<string, unknown>): StructuredLogger {
+    return new StructuredLogger({
+      stream: this.stream,
+      base: { ...this.base, ...normalizeFields(fields) },
+      metrics: this.metricsSinks,
+    });
+  }
+
+  log(level: LogLevel, message: string, fields?: Record<string, unknown>): void {
+    const entry = {
+      ts: new Date().toISOString(),
+      level,
+      msg: message,
+      ...this.base,
+      ...normalizeFields(fields),
+    };
+
+    this.stream.write(`${JSON.stringify(entry)}\n`);
+  }
+
+  debug(message: string, fields?: Record<string, unknown>): void {
+    this.log("debug", message, fields);
+  }
+
+  info(message: string, fields?: Record<string, unknown>): void {
+    this.log("info", message, fields);
+  }
+
+  warn(message: string, fields?: Record<string, unknown>): void {
+    this.log("warn", message, fields);
+  }
+
+  error(message: string, fields?: Record<string, unknown>): void {
+    this.log("error", message, fields);
+  }
+
+  startTimer(): () => number {
+    const start = process.hrtime.bigint();
+    return () => Number(process.hrtime.bigint() - start) / 1_000_000;
+  }
+
+  recordMetric(event: MetricEvent): void {
+    for (const sink of this.metricsSinks) {
+      Promise.resolve()
+        .then(() => sink(event))
+        .catch((error) => {
+          const details = error instanceof Error ? error.message : String(error);
+          this.stream.write(
+            `${JSON.stringify({
+              ts: new Date().toISOString(),
+              level: "warn",
+              msg: "metric_sink_error",
+              service: this.base.service,
+              error: details,
+            })}\n`
+          );
+        });
+    }
+  }
+
+  recordTiming(
+    name: string,
+    durationMs: number,
+    attributes?: Record<string, Primitive>
+  ): void {
+    this.recordMetric({
+      name,
+      value: durationMs,
+      type: "timing",
+      unit: "ms",
+      attributes,
+    });
+  }
+
+  async time<T>(
+    message: string,
+    fn: () => Promise<T> | T,
+    fields?: Record<string, unknown>,
+    metricName?: string
+  ): Promise<T> {
+    const stopTimer = this.startTimer();
+
+    try {
+      const result = await fn();
+      const durationMs = stopTimer();
+      this.info(message, { ...fields, durationMs });
+      if (metricName) {
+        this.recordTiming(metricName, durationMs, toMetricAttributes(fields));
+      }
+      return result;
+    } catch (error) {
+      const durationMs = stopTimer();
+      this.error(message, {
+        ...fields,
+        durationMs,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      if (metricName) {
+        this.recordTiming(metricName, durationMs, {
+          ...toMetricAttributes(fields),
+          error: "true",
+        });
+      }
+      throw error;
+    }
+  }
+}
+
+export function createStructuredLogger(
+  options: StructuredLoggerOptions = {}
+): StructuredLogger {
+  return new StructuredLogger(options);
+}

--- a/test/structured-logger.test.js
+++ b/test/structured-logger.test.js
@@ -1,0 +1,76 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { PassThrough } = require('node:stream');
+
+const distPath = path.join(__dirname, '..', 'dist', 'codex', 'observability.js');
+
+if (!fs.existsSync(distPath)) {
+  throw new Error(
+    'Structured logger build output missing. Run `npm run build:mcp` before executing this test suite.',
+  );
+}
+
+const { createStructuredLogger } = require(distPath);
+
+describe('Structured logger', () => {
+  test('emits JSON log lines with structured fields', () => {
+    const stream = new PassThrough();
+    const chunks = [];
+    stream.on('data', (chunk) => {
+      chunks.push(chunk.toString());
+    });
+
+    const logger = createStructuredLogger({
+      name: 'test-service',
+      stream,
+      base: { component: 'unit-test' },
+    });
+
+    logger.info('lane_selection', { lane: 'quick', confidence: 0.92 });
+
+    const [entry] = chunks
+      .join('')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+
+    expect(entry.msg).toBe('lane_selection');
+    expect(entry.lane).toBe('quick');
+    expect(entry.confidence).toBe(0.92);
+    expect(entry.component).toBe('unit-test');
+    expect(entry.service).toBe('test-service');
+  });
+
+  test('records timing metrics via sinks', async () => {
+    const stream = new PassThrough();
+    stream.resume();
+    const sink = jest.fn();
+
+    const logger = createStructuredLogger({
+      stream,
+      metrics: sink,
+    });
+
+    const result = await logger.time(
+      'tool_completed',
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return 'ok';
+      },
+      { operation: 'select_development_lane', lane: 'complex' },
+      'test.metric.duration',
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(result).toBe('ok');
+    expect(sink).toHaveBeenCalled();
+
+    const event = sink.mock.calls[0][0];
+    expect(event.name).toBe('test.metric.duration');
+    expect(event.type).toBe('timing');
+    expect(event.unit).toBe('ms');
+    expect(event.attributes.operation).toBe('select_development_lane');
+    expect(event.attributes.lane).toBe('complex');
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared structured logger with optional metrics sinks for the Codex MCP runtime
- emit JSON logs for lane selection, approval decisions, and tool execution in codex-server and runtime
- document observability controls and add a snapshot test that verifies the structured logger output format

## Testing
- npm run build:mcp
- npm test -- structured-logger

------
https://chatgpt.com/codex/tasks/task_e_68df72baea888326998e922c29b2bc9e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced structured JSON logging to stderr with optional context enrichment.
  - Added lightweight metrics output to stdout, including per-tool and workflow duration metrics.
  - Unified, detailed runtime logging for startup, environment detection, lane/workflow execution, tool outcomes, and errors.
  - Improved initialization timing and error reporting for clearer diagnostics.

- Documentation
  - Added Observability & Metrics guidance with examples.
  - Documented new configuration keys: CODEX_LOG_CONTEXT and CODEX_METRICS_STDOUT.
  - Included sample structured log entry and usage notes.

- Tests
  - Added tests validating structured log output and timing metrics emission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->