### PR TITLE
Add schema validation and tests for Codex routing overrides

### DIFF
--- a/src/mcp-server/codex-config.js
+++ b/src/mcp-server/codex-config.js
@@ -1,0 +1,2 @@
+/* eslint-disable unicorn/prefer-module */
+module.exports = require('./codex-config.ts');

--- a/src/mcp-server/codex-config.ts
+++ b/src/mcp-server/codex-config.ts
@@ -1,0 +1,257 @@
+import { z } from "zod";
+
+export interface ModelRoute {
+  provider: string;
+  model: string;
+  maxTokens?: number;
+}
+
+export type ModelRouteOverride = Partial<ModelRoute>;
+
+type CanonicalRouteKey = keyof typeof ROUTE_ALIAS_GROUPS;
+
+const ROUTE_ALIAS_GROUPS = {
+  quick: ["quick", "fast", "rapid"] as const,
+  complex: ["complex", "full", "orchestrator"] as const,
+  review: ["review", "reviewer", "audit", "governance"] as const,
+} as const;
+
+const OVERRIDE_FIELD_MAP = {
+  PROVIDER: "provider",
+  MODEL: "model",
+  MAX_TOKENS: "maxTokens",
+} as const satisfies Record<string, keyof RawOverrideInput>;
+
+type RawOverrideInput = {
+  provider?: string;
+  model?: string;
+  maxTokens?: string;
+};
+
+const aliasToCanonicalRoute = (() => {
+  const entries = new Map<string, CanonicalRouteKey>();
+  (Object.entries(ROUTE_ALIAS_GROUPS) as [CanonicalRouteKey, readonly string[]][]).forEach(
+    ([canonical, aliases]) => {
+      entries.set(canonical, canonical);
+      aliases.forEach((alias) => entries.set(alias.toLowerCase(), canonical));
+    }
+  );
+  return entries;
+})();
+
+const requiredTrimmedString = z
+  .string({
+    required_error: "value is required",
+    invalid_type_error: "value must be a string",
+  })
+  .transform((value) => value.trim())
+  .refine((value) => value.length > 0, {
+    message: "value must not be empty",
+  });
+
+const optionalTrimmedString = z
+  .string({ invalid_type_error: "value must be a string" })
+  .transform((value) => value.trim())
+  .refine((value) => value.length > 0, {
+    message: "value must not be empty",
+  })
+  .optional();
+
+const maxTokensSchema = z
+  .preprocess((value) => {
+    if (value == null) {
+      return undefined;
+    }
+
+    if (typeof value === "number") {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed === "") {
+        return undefined;
+      }
+
+      const parsed = Number.parseInt(trimmed, 10);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+
+      return trimmed;
+    }
+
+    return value;
+  }, z.number().int().positive())
+  .optional();
+
+const routeSchema = z
+  .object({
+    provider: requiredTrimmedString,
+    model: requiredTrimmedString,
+    maxTokens: maxTokensSchema,
+  })
+  .transform((value) => ({
+    provider: value.provider,
+    model: value.model,
+    ...(value.maxTokens !== undefined ? { maxTokens: value.maxTokens } : {}),
+  } satisfies ModelRoute));
+
+const overrideSchema = z
+  .object({
+    provider: optionalTrimmedString,
+    model: optionalTrimmedString,
+    maxTokens: maxTokensSchema,
+  })
+  .refine(
+    (value) =>
+      value.provider !== undefined ||
+      value.model !== undefined ||
+      value.maxTokens !== undefined,
+    {
+      message: "override must define at least one of provider, model, or maxTokens",
+    }
+  )
+  .transform((value) => {
+    const result: ModelRouteOverride = {};
+    if (value.provider !== undefined) {
+      result.provider = value.provider;
+    }
+    if (value.model !== undefined) {
+      result.model = value.model;
+    }
+    if (value.maxTokens !== undefined) {
+      result.maxTokens = value.maxTokens;
+    }
+    return result;
+  });
+
+const overridesSchema = z
+  .object({
+    quick: overrideSchema,
+    complex: overrideSchema,
+    review: overrideSchema,
+  })
+  .partial()
+  .transform((value) => value as Partial<Record<CanonicalRouteKey, ModelRouteOverride>>) // eslint-disable-line @typescript-eslint/consistent-type-assertions
+  .default({});
+
+const configSchema = z.object({
+  defaultRoute: routeSchema,
+  overrides: overridesSchema,
+});
+
+export interface CodexRoutingConfig {
+  defaultRoute: ModelRoute;
+  overrides: Partial<Record<CanonicalRouteKey, ModelRouteOverride>>;
+}
+
+function collectOverrideInputs(env: NodeJS.ProcessEnv) {
+  const overrides: Partial<Record<CanonicalRouteKey, RawOverrideInput>> = {};
+  const errors: string[] = [];
+
+  for (const [key, rawValue] of Object.entries(env)) {
+    if (rawValue == null) {
+      continue;
+    }
+
+    const match = /^CODEX_([A-Z0-9]+)_(PROVIDER|MODEL|MAX_TOKENS)$/.exec(key);
+    if (!match) {
+      continue;
+    }
+
+    const [, aliasTokenRaw, fieldToken] = match;
+    const aliasToken = aliasTokenRaw.toLowerCase();
+
+    if (aliasToken === "default") {
+      continue;
+    }
+
+    const canonical = aliasToCanonicalRoute.get(aliasToken);
+    if (!canonical) {
+      errors.push(`Unrecognized override alias "${aliasTokenRaw}" in ${key}`);
+      continue;
+    }
+
+    const field = OVERRIDE_FIELD_MAP[fieldToken as keyof typeof OVERRIDE_FIELD_MAP];
+    if (!field) {
+      continue;
+    }
+
+    const override = (overrides[canonical] ||= {});
+    const value = String(rawValue);
+
+    if (override[field] && override[field] !== value) {
+      errors.push(
+        `Conflicting values for ${canonical} ${field}: "${override[field]}" vs "${value}" (via ${key})`
+      );
+      continue;
+    }
+
+    override[field] = value;
+  }
+
+  return { overrides, errors };
+}
+
+function formatIssues(issues: z.ZodIssue[]): string {
+  return issues
+    .map((issue) => {
+      const path = issue.path.join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+}
+
+export function loadModelRoutingConfig(env: NodeJS.ProcessEnv): CodexRoutingConfig {
+  const defaultRouteInput = {
+    provider:
+      env.CODEX_DEFAULT_PROVIDER ?? env.CODEX_PROVIDER ?? env.LLM_PROVIDER ?? "claude",
+    model:
+      env.CODEX_DEFAULT_MODEL ?? env.CODEX_MODEL ?? env.LLM_MODEL ?? "claude-3-5-sonnet-20241022",
+    maxTokens: env.CODEX_MAX_TOKENS,
+  };
+
+  const { overrides: rawOverrides, errors } = collectOverrideInputs(env);
+
+  if (errors.length > 0) {
+    const message = `[Codex] Invalid CODEX override configuration: ${errors.join("; ")}`;
+    console.error(message);
+    throw new Error(message);
+  }
+
+  const overridesInput: Partial<Record<CanonicalRouteKey, RawOverrideInput>> = {};
+  (Object.entries(rawOverrides) as [CanonicalRouteKey, RawOverrideInput | undefined][]).forEach(
+    ([key, value]) => {
+      if (!value) {
+        return;
+      }
+
+      if (value.provider === undefined && value.model === undefined && value.maxTokens === undefined) {
+        return;
+      }
+
+      overridesInput[key] = value;
+    }
+  );
+
+  const validation = configSchema.safeParse({
+    defaultRoute: defaultRouteInput,
+    overrides: overridesInput,
+  });
+
+  if (!validation.success) {
+    const message = `[Codex] Invalid model routing configuration: ${formatIssues(validation.error.issues)}`;
+    console.error(message);
+    throw new Error(message);
+  }
+
+  const { defaultRoute, overrides } = validation.data;
+
+  return {
+    defaultRoute,
+    overrides,
+  };
+}
+
+export const ROUTE_ALIASES: Record<CanonicalRouteKey, readonly string[]> = ROUTE_ALIAS_GROUPS;

--- a/src/mcp-server/runtime.js
+++ b/src/mcp-server/runtime.js
@@ -1,0 +1,2 @@
+/* eslint-disable unicorn/prefer-module */
+module.exports = require('./runtime.ts');

--- a/test/codex-routing-config.test.js
+++ b/test/codex-routing-config.test.js
@@ -1,0 +1,179 @@
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const NODE_EXEC = process.execPath;
+const TS_NODE_REGISTER = 'ts-node/register';
+const TS_NODE_PROJECT_PATH = path.resolve(__dirname, '../tsconfig.codex.json');
+const CODEX_CONFIG_PATH = path.resolve(__dirname, '../src/mcp-server/codex-config.ts');
+const CODEX_SERVER_PATH = path.resolve(__dirname, '../src/mcp-server/codex-server.ts');
+
+function runLoadModelRoutingConfig(envOverrides = {}) {
+  const script = `
+    const { loadModelRoutingConfig } = require(${JSON.stringify(CODEX_CONFIG_PATH)});
+    try {
+      const result = loadModelRoutingConfig(process.env);
+      console.log(JSON.stringify({ ok: true, result }));
+    } catch (error) {
+      console.error(error.message);
+      console.log(JSON.stringify({ ok: false, message: error.message }));
+      process.exit(1);
+    }
+  `;
+
+  return spawnSync(NODE_EXEC, ['-r', TS_NODE_REGISTER, '-e', script], {
+    env: {
+      ...process.env,
+      ...envOverrides,
+      TS_NODE_PREFER_TS_EXTS: 'true',
+      TS_NODE_PROJECT: TS_NODE_PROJECT_PATH,
+      TS_NODE_COMPILER_OPTIONS: JSON.stringify({
+        module: 'nodenext',
+        moduleResolution: 'nodenext',
+      }),
+      CODEX_DISABLE_AUTORUN: 'true',
+    },
+    encoding: 'utf8',
+  });
+}
+
+function runCodexClient(envOverrides = {}) {
+  const script = `
+    process.env.CODEX_DISABLE_AUTORUN = "true";
+    const { CodexClient } = require(${JSON.stringify(CODEX_SERVER_PATH)});
+    const client = CodexClient.fromEnvironment();
+    const router = client.router;
+    const quick = router.resolve("fast");
+    const review = router.resolve("governance");
+    console.log(JSON.stringify({ quick, review }));
+  `;
+
+  return spawnSync(NODE_EXEC, ['-r', TS_NODE_REGISTER, '-e', script], {
+    env: {
+      ...process.env,
+      ...envOverrides,
+      TS_NODE_PREFER_TS_EXTS: 'true',
+      TS_NODE_PROJECT: TS_NODE_PROJECT_PATH,
+      TS_NODE_COMPILER_OPTIONS: JSON.stringify({
+        module: 'nodenext',
+        moduleResolution: 'nodenext',
+      }),
+    },
+    encoding: 'utf8',
+  });
+}
+
+function parseStdout(output) {
+  const trimmed = output.trim();
+  return trimmed ? JSON.parse(trimmed) : undefined;
+}
+
+describe('Codex routing configuration', () => {
+  it('normalizes alias overrides and supports friendly names', () => {
+    const env = {
+      CODEX_DEFAULT_PROVIDER: 'anthropic',
+      CODEX_DEFAULT_MODEL: 'claude-default',
+      CODEX_FAST_PROVIDER: 'openai',
+      CODEX_QUICK_MODEL: 'gpt-quick',
+      CODEX_REVIEW_MAX_TOKENS: '4096',
+      CODEX_GOVERNANCE_MODEL: 'audit-model',
+    };
+
+    const configRun = runLoadModelRoutingConfig(env);
+    expect(configRun.status).toBe(0);
+    expect(configRun.stderr.trim()).toBe('');
+
+    const parsed = parseStdout(configRun.stdout);
+    expect(parsed).toEqual({
+      ok: true,
+      result: {
+        defaultRoute: { provider: 'anthropic', model: 'claude-default' },
+        overrides: {
+          quick: { provider: 'openai', model: 'gpt-quick' },
+          review: { model: 'audit-model', maxTokens: 4096 },
+        },
+      },
+    });
+
+    const clientRun = runCodexClient(env);
+    expect(clientRun.status).toBe(0);
+    expect(clientRun.stderr.trim()).toBe('');
+    const clientParsed = parseStdout(clientRun.stdout);
+    expect(clientParsed).toEqual({
+      quick: { provider: 'openai', model: 'gpt-quick' },
+      review: { provider: 'anthropic', model: 'audit-model', maxTokens: 4096 },
+    });
+  });
+
+  it('rejects unrecognized override aliases', () => {
+    const env = {
+      CODEX_SPEEDY_MODEL: 'fast-model',
+    };
+
+    const result = runLoadModelRoutingConfig(env);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[Codex] Invalid CODEX override configuration: Unrecognized override alias "SPEEDY" in CODEX_SPEEDY_MODEL',
+    );
+    const parsed = parseStdout(result.stdout);
+    expect(parsed).toEqual({
+      ok: false,
+      message:
+        '[Codex] Invalid CODEX override configuration: Unrecognized override alias "SPEEDY" in CODEX_SPEEDY_MODEL',
+    });
+  });
+
+  it('detects conflicting alias values', () => {
+    const env = {
+      CODEX_QUICK_MODEL: 'model-A',
+      CODEX_FAST_MODEL: 'model-B',
+    };
+
+    const result = runLoadModelRoutingConfig(env);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[Codex] Invalid CODEX override configuration: Conflicting values for quick model: "model-A" vs "model-B" (via CODEX_FAST_MODEL)',
+    );
+    const parsed = parseStdout(result.stdout);
+    expect(parsed).toEqual({
+      ok: false,
+      message:
+        '[Codex] Invalid CODEX override configuration: Conflicting values for quick model: "model-A" vs "model-B" (via CODEX_FAST_MODEL)',
+    });
+  });
+
+  it('validates max token overrides', () => {
+    const env = {
+      CODEX_REVIEW_MAX_TOKENS: 'not-a-number',
+    };
+
+    const result = runLoadModelRoutingConfig(env);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[Codex] Invalid model routing configuration: overrides.review.maxTokens: Expected number, received string',
+    );
+    const parsed = parseStdout(result.stdout);
+    expect(parsed).toEqual({
+      ok: false,
+      message:
+        '[Codex] Invalid model routing configuration: overrides.review.maxTokens: Expected number, received string',
+    });
+  });
+
+  it('enforces required default route fields', () => {
+    const env = {
+      CODEX_DEFAULT_PROVIDER: '   ',
+    };
+
+    const result = runLoadModelRoutingConfig(env);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[Codex] Invalid model routing configuration: defaultRoute.provider: value must not be empty',
+    );
+    const parsed = parseStdout(result.stdout);
+    expect(parsed).toEqual({
+      ok: false,
+      message:
+        '[Codex] Invalid model routing configuration: defaultRoute.provider: value must not be empty',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a codex-config helper that uses zod to validate default routing plus quick/complex/review overrides and canonicalize aliases
- wire CodexClient.fromEnvironment through the validated config, normalize override maps, and honor CODEX_DISABLE_AUTORUN to avoid accidental startup when imported
- cover valid/invalid override combinations with regression tests that exercise the helper and CodexClient via ts-node subprocesses

## Testing
- npm test -- codex-routing-config

------
https://chatgpt.com/codex/tasks/task_e_68df72b05e0883268fe7eef0d7de95af