### PR TITLE
Add Codex approval and orchestrator integration tests

### DIFF
--- a/test/codex-approval.test.js
+++ b/test/codex-approval.test.js
@@ -1,0 +1,135 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { createRequire } = require('node:module');
+
+function loadCodexTestHarness() {
+  const filePath = path.join(__dirname, '..', 'dist', 'codex', 'codex-server.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+
+  source = source.replace(
+    'async function main() {',
+    'globalThis.__CODEX_TEST_HOOKS = { CodexClient, ModelRouter, normalizeOperation };\nasync function main() {',
+  );
+
+  source = source.replace(
+    'main().catch((error) => {',
+    'if (process.env.__CODEX_TEST__ !== "1") main().catch((error) => {',
+  );
+
+  const moduleRequire = createRequire(filePath);
+  const sandboxProcess = {
+    ...process,
+    env: { ...process.env, __CODEX_TEST__: '1' },
+    exit: () => {},
+  };
+
+  const sandbox = {
+    module: { exports: {} },
+    exports: {},
+    require: moduleRequire,
+    process: sandboxProcess,
+    console,
+    __dirname: path.dirname(filePath),
+    __filename: filePath,
+  };
+
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  const hooks = sandbox.__CODEX_TEST_HOOKS;
+  if (!hooks) {
+    throw new Error('Failed to load Codex test hooks');
+  }
+
+  return { ...hooks, process: sandboxProcess };
+}
+
+describe('CodexClient approval guardrails', () => {
+  let harness;
+
+  beforeEach(() => {
+    harness = loadCodexTestHarness();
+  });
+
+  it('allows operations freely when approval mode is disabled', async () => {
+    harness.process.env = {};
+    const client = harness.CodexClient.fromEnvironment();
+
+    await expect(client.ensureOperationAllowed('generate_deliverable')).resolves.toBeUndefined();
+    await expect(
+      client.ensureOperationAllowed('execute_quick_lane', { decision: { lane: 'quick' } }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('blocks operations when approval mode is enabled without matching approvals', async () => {
+    harness.process.env = {
+      CODEX_APPROVAL_MODE: 'true',
+      CODEX_AUTO_APPROVE: 'false',
+      CODEX_APPROVED_OPERATIONS: 'generate_deliverable, execute_complex_lane@complex',
+    };
+
+    const client = harness.CodexClient.fromEnvironment();
+
+    await expect(
+      client.ensureOperationAllowed('Execute_Complex_Lane', {
+        decision: { lane: 'complex' },
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(client.ensureOperationAllowed('Execute_Quick_Lane')).rejects.toThrow(
+      'Operation "Execute_Quick_Lane" blocked by Codex approval mode.',
+    );
+  });
+
+  it('normalizes metadata overrides for approval matching', async () => {
+    harness.process.env = {
+      CODEX_APPROVAL_MODE: '1',
+      CODEX_AUTO_APPROVE: '0',
+      CODEX_APPROVED_OPERATIONS:
+        ' generate_deliverable:Story ; execute_quick_lane@FAST , run_review_checkpoint:final ',
+    };
+
+    const client = harness.CodexClient.fromEnvironment();
+
+    await expect(
+      client.ensureOperationAllowed('Generate_Deliverable', { type: 'story' }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      client.ensureOperationAllowed('execute_quick_lane', { decision: { lane: 'fast' } }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      client.ensureOperationAllowed('run_review_checkpoint', { type: 'FINAL' }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      client.ensureOperationAllowed('run_review_checkpoint', { type: 'initial' }),
+    ).rejects.toThrow('Operation "run_review_checkpoint" blocked by Codex approval mode.');
+
+    const normalized = harness.normalizeOperation('Generate_Deliverable', {
+      type: 'Story',
+      decision: { lane: 'Quick' },
+    });
+
+    expect(normalized).toEqual(
+      expect.arrayContaining([
+        'generate_deliverable',
+        'generate_deliverable:story',
+        'generate_deliverable@quick',
+      ]),
+    );
+  });
+
+  it('bypasses approvals when auto-approve is enabled', async () => {
+    harness.process.env = {
+      CODEX_APPROVAL_MODE: 'yes',
+      CODEX_AUTO_APPROVE: 'true',
+    };
+
+    const client = harness.CodexClient.fromEnvironment();
+
+    await expect(
+      client.ensureOperationAllowed('delete_repository', { scope: 'all' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/test/run-orchestrator-server.integration.test.js
+++ b/test/run-orchestrator-server.integration.test.js
@@ -1,0 +1,489 @@
+/* eslint-disable n/no-unpublished-require */
+const path = require('node:path');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const { createRequire } = require('node:module');
+const { pathToFileURL } = require('node:url');
+
+const laneDecisionsQueue = [];
+
+jest.mock('@modelcontextprotocol/sdk/server/index.js', () => {
+  const instances = [];
+
+  class FakeServer {
+    constructor(info, options) {
+      this.info = info;
+      this.options = options;
+      this.handlers = new Map();
+    }
+
+    setRequestHandler(schema, handler) {
+      this.handlers.set(schema, handler);
+    }
+
+    async connect(transport) {
+      this.transport = transport;
+      if (transport?.start) {
+        await transport.start();
+      }
+    }
+  }
+
+  const Server = jest.fn().mockImplementation((info, options) => {
+    const instance = new FakeServer(info, options);
+    instances.push(instance);
+    return instance;
+  });
+
+  return { Server, __instances: instances };
+});
+
+jest.mock('../lib/lane-selector.js', () => {
+  const selectLaneWithLog = jest.fn(async () =>
+    laneDecisionsQueue.length > 0
+      ? laneDecisionsQueue.shift()
+      : { lane: 'quick', rationale: 'default', confidence: 0.75 },
+  );
+
+  return { selectLaneWithLog, __laneDecisionsQueue: laneDecisionsQueue };
+});
+
+const mockQuickLaneExecute = jest.fn();
+const mockQuickLaneInitialize = jest.fn();
+
+jest.mock('../lib/quick-lane.js', () => {
+  const QuickLane = jest.fn().mockImplementation(() => ({
+    initialize: mockQuickLaneInitialize,
+    execute: mockQuickLaneExecute,
+  }));
+
+  return {
+    QuickLane,
+    __quickLaneMocks: { execute: mockQuickLaneExecute, initialize: mockQuickLaneInitialize },
+  };
+});
+
+const mockBridgeInitialize = jest.fn();
+const mockRunAgent = jest.fn();
+const mockExecutePhaseWorkflow = jest.fn();
+const mockLoadAgent = jest.fn();
+const mockListAgents = jest.fn();
+const mockGetEnvironmentInfo = jest.fn();
+
+jest.mock('../lib/bmad-bridge.js', () => {
+  const BMADBridge = jest.fn().mockImplementation(() => ({
+    initialize: mockBridgeInitialize,
+    getEnvironmentInfo: mockGetEnvironmentInfo,
+    runAgent: mockRunAgent,
+    executePhaseWorkflow: mockExecutePhaseWorkflow,
+    loadAgent: mockLoadAgent,
+    listAgents: mockListAgents,
+  }));
+
+  return {
+    BMADBridge,
+    __bridgeMocks: {
+      initializeMock: mockBridgeInitialize,
+      runAgentMock: mockRunAgent,
+      executePhaseWorkflowMock: mockExecutePhaseWorkflow,
+      loadAgentMock: mockLoadAgent,
+      listAgentsMock: mockListAgents,
+      getEnvironmentInfoMock: mockGetEnvironmentInfo,
+    },
+  };
+});
+
+const mockGeneratorInitialize = jest.fn();
+const mockGenerateBrief = jest.fn();
+const mockGeneratePRD = jest.fn();
+const mockGenerateArchitecture = jest.fn();
+const mockGenerateEpic = jest.fn();
+const mockGenerateStory = jest.fn();
+const mockGenerateQA = jest.fn();
+
+jest.mock('../lib/deliverable-generator.js', () => {
+  const DeliverableGenerator = jest.fn().mockImplementation(() => ({
+    initialize: mockGeneratorInitialize,
+    generateBrief: mockGenerateBrief,
+    generatePRD: mockGeneratePRD,
+    generateArchitecture: mockGenerateArchitecture,
+    generateEpic: mockGenerateEpic,
+    generateStory: mockGenerateStory,
+    generateQAAssessment: mockGenerateQA,
+  }));
+
+  return {
+    DeliverableGenerator,
+    __generatorMocks: {
+      initialize: mockGeneratorInitialize,
+      generateBrief: mockGenerateBrief,
+      generatePRD: mockGeneratePRD,
+      generateArchitecture: mockGenerateArchitecture,
+      generateEpic: mockGenerateEpic,
+      generateStory: mockGenerateStory,
+      generateQAAssessment: mockGenerateQA,
+    },
+  };
+});
+
+const mockScanCodebase = jest.fn();
+const mockDetectDocs = jest.fn();
+const mockDetectState = jest.fn();
+const mockSummarizeCodebase = jest.fn();
+
+jest.mock('../lib/brownfield-analyzer.js', () => {
+  const BrownfieldAnalyzer = jest.fn().mockImplementation(() => ({
+    scanCodebase: mockScanCodebase,
+    detectExistingDocs: mockDetectDocs,
+    detectPreviousState: mockDetectState,
+    generateCodebaseSummary: mockSummarizeCodebase,
+  }));
+
+  return {
+    BrownfieldAnalyzer,
+    __brownfieldMocks: {
+      scanCodebase: mockScanCodebase,
+      detectExistingDocs: mockDetectDocs,
+      detectPreviousState: mockDetectState,
+      generateCodebaseSummary: mockSummarizeCodebase,
+    },
+  };
+});
+
+const mockExecuteAutoCommand = jest.fn();
+
+jest.mock('../lib/auto-commands.js', () => ({
+  executeAutoCommand: mockExecuteAutoCommand,
+}));
+
+let mockLastProjectStateInstance;
+
+jest.mock('../lib/project-state.js', () => {
+  const ProjectState = jest.fn().mockImplementation((projectPath) => {
+    const deliverables = {};
+    const instance = {
+      projectPath,
+      state: {
+        currentPhase: 'analyst',
+        decisions: {},
+        requirements: {},
+        phaseHistory: [],
+      },
+      deliverables,
+      conversation: [],
+      initialize: jest.fn().mockResolvedValue(),
+      getState: jest.fn(() => ({ ...instance.state })),
+      updateState: jest.fn().mockResolvedValue(),
+      storeDeliverable: jest.fn(async (type, content, metadata = {}) => {
+        deliverables[type] = { content, metadata };
+      }),
+      getPhaseDeliverables: jest.fn().mockResolvedValue([]),
+      getDeliverable: jest.fn((type) => deliverables[type]),
+      getDeliverablesByType: jest.fn((type) => (deliverables[type] ? [deliverables[type]] : [])),
+      recordLaneDecision: jest.fn(async (lane, rationale, confidence, trigger) => {
+        instance.state.currentLane = lane;
+        instance.state.laneHistory = instance.state.laneHistory || [];
+        instance.state.laneHistory.push({ lane, rationale, confidence, trigger });
+      }),
+      recordDecision: jest.fn().mockResolvedValue(),
+      addMessage: jest.fn().mockResolvedValue(),
+      getConversation: jest.fn(() => []),
+      getSummary: jest.fn(() => ({ status: 'ok' })),
+      setDeveloperContext: jest.fn(),
+      trackDeveloperContext: jest.fn(),
+    };
+
+    mockLastProjectStateInstance = instance;
+    return instance;
+  });
+
+  return { ProjectState, __getLastInstance: () => mockLastProjectStateInstance };
+});
+
+const boundDepsHolder = { current: null };
+const mockBindDependencies = jest.fn((deps) => {
+  boundDepsHolder.current = deps;
+});
+const mockCheckTransition = jest.fn();
+const mockHandleTransition = jest.fn();
+
+jest.mock('../hooks/phase-transition.js', () => ({
+  bindDependencies: mockBindDependencies,
+  checkTransition: mockCheckTransition,
+  handleTransition: mockHandleTransition,
+  __getBoundDeps: () => boundDepsHolder.current,
+  __resetBoundDeps: () => {
+    boundDepsHolder.current = null;
+  },
+}));
+
+const mockPreserveContext = jest.fn();
+
+jest.mock('../hooks/context-preservation.js', () => ({
+  preserveContext: mockPreserveContext,
+}));
+
+const mockRunStoryContextValidation = jest.fn();
+const mockEnsureStoryContextReady = jest.fn();
+
+jest.mock('../lib/story-context-validator.js', () => {
+  const api = {
+    runStoryContextValidation: mockRunStoryContextValidation,
+    ensureStoryContextReadyForDevelopment: mockEnsureStoryContextReady,
+  };
+
+  return { ...api, default: api };
+});
+
+const { __instances: serverInstances } = require('@modelcontextprotocol/sdk/server/index.js');
+const laneSelector = require('../lib/lane-selector.js');
+const quickLaneModule = require('../lib/quick-lane.js');
+const bridgeModule = require('../lib/bmad-bridge.js');
+const deliverableGeneratorModule = require('../lib/deliverable-generator.js');
+const projectStateModule = require('../lib/project-state.js');
+const phaseTransitionModule = require('../hooks/phase-transition.js');
+function loadRuntimeForTests() {
+  const filePath = path.resolve(__dirname, '../dist/codex/runtime.js');
+  let source = fs.readFileSync(filePath, 'utf8');
+  source = source.replace(
+    '"use strict";',
+    '"use strict";\nconst dynamicRequire = (specifier) => Promise.resolve(require(specifier));',
+  );
+  source = source.replaceAll('await import(', 'await dynamicRequire(');
+  const moduleRequire = createRequire(pathToFileURL(filePath));
+  const moduleExports = {};
+  const sandbox = {
+    module: { exports: moduleExports },
+    exports: moduleExports,
+    require: moduleRequire,
+    process,
+    console,
+    __dirname: path.dirname(filePath),
+    __filename: filePath,
+  };
+  vm.runInNewContext(source, sandbox, { filename: filePath });
+  return sandbox.module.exports;
+}
+
+const { runOrchestratorServer } = loadRuntimeForTests();
+
+const { CallToolRequestSchema } = require('@modelcontextprotocol/sdk/types.js');
+
+async function setupServer(options = {}) {
+  const transport = options.transport ?? { start: jest.fn().mockResolvedValue() };
+  const ensureOperationAllowed = options.ensureOperationAllowed ?? jest.fn().mockResolvedValue();
+  const createLLMClient = options.createLLMClient ?? jest.fn().mockResolvedValue({});
+
+  await runOrchestratorServer({
+    transport,
+    ensureOperationAllowed,
+    createLLMClient,
+    log: options.log ?? jest.fn(),
+  });
+
+  const server = serverInstances.at(-1);
+  return { server, transport, ensureOperationAllowed, createLLMClient };
+}
+
+describe('runOrchestratorServer integration flows', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    laneSelector.__laneDecisionsQueue.length = 0;
+    serverInstances.length = 0;
+    phaseTransitionModule.__resetBoundDeps();
+
+    quickLaneModule.__quickLaneMocks.initialize.mockResolvedValue();
+    quickLaneModule.__quickLaneMocks.execute.mockImplementation(async () => ({
+      message: 'quick-complete',
+      files: ['docs/prd.md'],
+    }));
+
+    bridgeModule.__bridgeMocks.initializeMock.mockResolvedValue();
+    bridgeModule.__bridgeMocks.getEnvironmentInfoMock.mockReturnValue({
+      mode: 'v6-modules',
+      root: '/tmp/project',
+      catalog: { moduleCount: 2 },
+    });
+    bridgeModule.__bridgeMocks.executePhaseWorkflowMock.mockImplementation(async () => ({
+      ok: true,
+    }));
+    bridgeModule.__bridgeMocks.runAgentMock.mockResolvedValue({
+      response: JSON.stringify({ ok: true }),
+    });
+    bridgeModule.__bridgeMocks.loadAgentMock.mockResolvedValue({ content: 'Agent persona' });
+    bridgeModule.__bridgeMocks.listAgentsMock.mockResolvedValue(['analyst', 'pm']);
+
+    deliverableGeneratorModule.__generatorMocks.initialize.mockResolvedValue();
+    deliverableGeneratorModule.__generatorMocks.generateBrief.mockResolvedValue({
+      path: 'docs/brief.md',
+      content: '# brief',
+    });
+    deliverableGeneratorModule.__generatorMocks.generatePRD.mockResolvedValue({
+      path: 'docs/prd.md',
+      content: '# prd',
+    });
+    deliverableGeneratorModule.__generatorMocks.generateArchitecture.mockResolvedValue({
+      path: 'docs/architecture.md',
+      content: '# architecture',
+    });
+    deliverableGeneratorModule.__generatorMocks.generateEpic.mockResolvedValue({
+      path: 'docs/epic.md',
+      content: '# epic',
+    });
+    deliverableGeneratorModule.__generatorMocks.generateStory.mockResolvedValue({
+      path: 'docs/story.md',
+      content: '# story',
+    });
+    deliverableGeneratorModule.__generatorMocks.generateQAAssessment.mockResolvedValue({
+      path: 'docs/qa.md',
+      content: '# qa',
+    });
+
+    phaseTransitionModule.bindDependencies.mockClear();
+    phaseTransitionModule.checkTransition.mockResolvedValue(null);
+    phaseTransitionModule.handleTransition.mockImplementation(async (projectState, toPhase) => ({
+      transitionedTo: toPhase,
+    }));
+
+    mockPreserveContext.mockImplementation(async (fromPhase, toPhase, context) => context);
+    mockRunStoryContextValidation.mockResolvedValue({
+      checkpoint: 'chk-123',
+      status: 'ok',
+      issues: [],
+      record: { status: 'ok' },
+    });
+    mockEnsureStoryContextReady.mockResolvedValue({
+      record: { status: 'ready' },
+    });
+
+    mockExecuteAutoCommand.mockResolvedValue({ status: 'ok' });
+  });
+
+  it('executes the quick lane workflow and honors approval gating', async () => {
+    laneSelector.__laneDecisionsQueue.push({
+      lane: 'quick',
+      rationale: 'fast path',
+      confidence: 0.82,
+    });
+
+    const ensureOperationAllowed = jest.fn().mockResolvedValue();
+    const createLLMClient = jest.fn().mockResolvedValue({ client: true });
+    const { server } = await setupServer({ ensureOperationAllowed, createLLMClient });
+
+    const callTool = server.handlers.get(CallToolRequestSchema);
+    expect(typeof callTool).toBe('function');
+
+    quickLaneModule.__quickLaneMocks.execute.mockResolvedValueOnce({
+      message: 'Quick lane done',
+      files: ['docs/prd.md'],
+    });
+
+    const response = await callTool({
+      params: {
+        name: 'execute_workflow',
+        arguments: { userRequest: 'Ship login', context: {} },
+      },
+    });
+
+    const payload = JSON.parse(response.content[0].text);
+    expect(payload.lane).toBe('quick');
+    expect(payload.decision.lane).toBe('quick');
+    expect(quickLaneModule.__quickLaneMocks.execute).toHaveBeenCalledWith(
+      'Ship login',
+      expect.objectContaining({ previousPhase: 'analyst' }),
+    );
+    expect(ensureOperationAllowed).toHaveBeenCalledWith(
+      'execute_quick_lane',
+      expect.objectContaining({
+        decision: expect.objectContaining({ lane: 'quick' }),
+        request: 'Ship login',
+      }),
+    );
+    expect(createLLMClient).toHaveBeenCalledWith('quick');
+  });
+
+  it('executes the complex lane workflow, saving deliverables with approval hooks', async () => {
+    laneSelector.__laneDecisionsQueue.push({
+      lane: 'complex',
+      rationale: 'deep dive',
+      confidence: 0.91,
+    });
+
+    const ensureOperationAllowed = jest.fn().mockResolvedValue();
+
+    bridgeModule.__bridgeMocks.executePhaseWorkflowMock.mockImplementation(
+      async (phase, context) => {
+        const deps = phaseTransitionModule.__getBoundDeps();
+        if (phase === 'sm' && deps?.saveDeliverable) {
+          await deps.saveDeliverable('architecture', '# plan');
+        }
+
+        return { phase, context };
+      },
+    );
+
+    const { server } = await setupServer({ ensureOperationAllowed });
+
+    const callTool = server.handlers.get(CallToolRequestSchema);
+
+    const response = await callTool({
+      params: {
+        name: 'execute_workflow',
+        arguments: { userRequest: 'Build analytics suite', context: {} },
+      },
+    });
+
+    const payload = JSON.parse(response.content[0].text);
+    expect(payload.lane).toBe('complex');
+    expect(bridgeModule.__bridgeMocks.executePhaseWorkflowMock).toHaveBeenCalledTimes(4);
+    expect(bridgeModule.__bridgeMocks.executePhaseWorkflowMock).toHaveBeenNthCalledWith(
+      1,
+      'analyst',
+      expect.objectContaining({ userMessage: 'Build analytics suite' }),
+    );
+    expect(ensureOperationAllowed).toHaveBeenCalledWith(
+      'execute_complex_lane',
+      expect.objectContaining({ decision: expect.objectContaining({ lane: 'complex' }) }),
+    );
+
+    const projectState = projectStateModule.__getLastInstance();
+    expect(projectState.storeDeliverable).toHaveBeenCalledWith('architecture', '# plan');
+
+    expect(ensureOperationAllowed).toHaveBeenCalledWith(
+      'save_deliverable',
+      expect.objectContaining({ type: 'architecture' }),
+    );
+  });
+
+  it('propagates malformed agent responses as tool errors', async () => {
+    const ensureOperationAllowed = jest.fn().mockResolvedValue();
+    bridgeModule.__bridgeMocks.runAgentMock.mockResolvedValue({ response: 'not-json' });
+
+    phaseTransitionModule.handleTransition.mockImplementation(
+      async (projectState, toPhase, context = {}) => {
+        const deps = phaseTransitionModule.__getBoundDeps();
+        const agentResult = await deps.triggerAgent(
+          context.agentId ?? 'qa',
+          context.agentContext ?? {},
+        );
+        if (agentResult?.error) {
+          throw new Error(`Agent failure: ${agentResult.error}`);
+        }
+        return agentResult;
+      },
+    );
+
+    const { server } = await setupServer({ ensureOperationAllowed });
+
+    const callTool = server.handlers.get(CallToolRequestSchema);
+    const response = await callTool({
+      params: {
+        name: 'transition_phase',
+        arguments: { toPhase: 'dev', context: { agentId: 'qa' } },
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('Failed to parse response from agent qa');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Codex approval suite that exercises fromEnvironment behaviour across approval-mode permutations and operation normalization
- build an orchestrator integration suite with mocked dependencies to validate quick/complex lane execution paths and error propagation

## Testing
- npm test --silent -- test/codex-approval.test.js test/run-orchestrator-server.integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df72b6fab48326a71e4202885d60e1