### PR TITLE
Set Claude as default assistant in CLI

### DIFF
--- a/bin/bmad-invisible
+++ b/bin/bmad-invisible
@@ -32,7 +32,7 @@ Usage:
 
 Commands:
 
-  start                🚀 ONE-COMMAND SETUP: init + install + launch chat (Codex default)
+  start                🚀 ONE-COMMAND SETUP: init + install + launch chat (Claude default)
   init                 Initialize BMAD-invisible in current project
   codex                Start conversational interface (requires Codex CLI)
   chat                 Start conversational interface with Claude CLI (legacy)
@@ -61,7 +61,7 @@ For more information: https://github.com/bacoco/BMAD-invisible
 };
 
 const ASSISTANT_CHOICES = ['codex', 'claude', 'opencode'];
-const DEFAULT_ASSISTANT = 'codex';
+const DEFAULT_ASSISTANT = 'claude';
 
 const formatAssistantName = (value) =>
   value.charAt(0).toUpperCase() + value.slice(1);
@@ -136,7 +136,7 @@ const promptForAssistant = () =>
           return;
         }
 
-        console.log('⚠️ Unrecognized selection. Defaulting to Codex.');
+        console.log('⚠️ Unrecognized selection. Defaulting to Claude.');
         resolve(DEFAULT_ASSISTANT);
       },
     );
@@ -148,7 +148,7 @@ const determineAssistant = async (flagValue) => {
       return flagValue;
     }
 
-    console.log('⚠️ Unsupported assistant flag value. Defaulting to Codex.');
+    console.log('⚠️ Unsupported assistant flag value. Defaulting to Claude.');
     return DEFAULT_ASSISTANT;
   }
 

--- a/test/bmad-invisible-cli.test.js
+++ b/test/bmad-invisible-cli.test.js
@@ -40,7 +40,7 @@ describe('bmad-invisible start assistant selection', () => {
     process.stdout.isTTY = originalIsTTY;
   });
 
-  test('defaults to Codex when no assistant flag is provided', async () => {
+  test('defaults to Claude when no assistant flag is provided', async () => {
     process.stdout.isTTY = false;
     cli.setRuntimeContext('start', []);
 
@@ -49,7 +49,7 @@ describe('bmad-invisible start assistant selection', () => {
     expect(mockSpawn).toHaveBeenCalled();
     const lastCall = mockSpawn.mock.calls.at(-1);
     expect(lastCall[0]).toBe('node');
-    expect(lastCall[1][0]).toContain(path.join('bin', 'bmad-codex'));
+    expect(lastCall[1][0]).toContain(path.join('bin', 'bmad-chat'));
     expect(lastCall[1].some((arg) => arg.includes('--assistant'))).toBe(false);
   });
 
@@ -75,7 +75,7 @@ describe('bmad-invisible start assistant selection', () => {
     expect(lastCall[2].shell).toBe(false);
   });
 
-  test('handles invalid assistant flag by defaulting to Codex', async () => {
+  test('handles invalid assistant flag by defaulting to Claude', async () => {
     process.stdout.isTTY = false;
     cli.setRuntimeContext('start', ['--assistant=invalid']);
 
@@ -83,7 +83,7 @@ describe('bmad-invisible start assistant selection', () => {
 
     const lastCall = mockSpawn.mock.calls.at(-1);
     expect(lastCall[0]).toBe('node');
-    expect(lastCall[1][0]).toContain(path.join('bin', 'bmad-codex'));
+    expect(lastCall[1][0]).toContain(path.join('bin', 'bmad-chat'));
   });
 
   test('handles spawn error for Codex', async () => {


### PR DESCRIPTION
## Summary
- set the default assistant for the CLI entry point to Claude
- update fallback messaging so interactive prompts and help text reference Claude

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df7f15436c832680cff8e8a9ee82c6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CLI default assistant changed to Claude; when no valid selection or an unsupported flag is used, it now falls back to Claude.
  * User-facing prompts, fallback messages, and default prompts updated to reflect Claude.
  * Start flow and commands continue to initialize and install with the selected assistant; only the default selection changed.

* **Tests**
  * Test expectations updated to reflect Claude as the new default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->