### PR TITLE
Add BMADBridge V6 module detection test

### DIFF
--- a/test/bmad-bridge.v6-mode.test.js
+++ b/test/bmad-bridge.v6-mode.test.js
@@ -1,0 +1,111 @@
+const fs = require('fs-extra');
+const os = require('node:os');
+const path = require('node:path');
+
+const { V6ModuleLoader } = require('../lib/v6-module-loader.js');
+globalThis.V6ModuleLoader = V6ModuleLoader;
+const { BMADBridge } = require('../lib/bmad-bridge.js');
+
+async function createV6Workspace() {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-v6-workspace-'));
+  const moduleRoot = path.join(tempRoot, 'src', 'modules', 'alpha');
+
+  await fs.ensureDir(path.join(moduleRoot, 'agents'));
+  await fs.ensureDir(path.join(moduleRoot, 'templates'));
+
+  const agentContent = `# Alpha Agent\n\n\`\`\`yaml\nagent:\n  id: alpha-agent\n  name: Alpha Agent\n  persona: { role: "Planner" }\n\`\`\`\n\nSample agent body.`;
+  await fs.writeFile(path.join(moduleRoot, 'agents', 'alpha-agent.md'), agentContent, 'utf8');
+
+  const templateContent = 'Hello {{name}}!\nRemember to pursue {{goal}}.';
+  await fs.writeFile(
+    path.join(moduleRoot, 'templates', 'alpha-template.md'),
+    templateContent,
+    'utf8',
+  );
+
+  return tempRoot;
+}
+
+describe('BMADBridge V6 module detection', () => {
+  let tempRoot;
+  let pathExistsSpy;
+  let readFileSpy;
+  let realPathExists;
+  let realReadFile;
+
+  afterEach(async () => {
+    if (pathExistsSpy) {
+      pathExistsSpy.mockRestore();
+      pathExistsSpy = undefined;
+    }
+
+    if (readFileSpy) {
+      readFileSpy.mockRestore();
+      readFileSpy = undefined;
+    }
+
+    if (tempRoot && (await fs.pathExists(tempRoot))) {
+      await fs.remove(tempRoot);
+      tempRoot = undefined;
+    }
+  });
+
+  test('initializes in V6 mode and delegates to V6ModuleLoader', async () => {
+    tempRoot = await createV6Workspace();
+
+    realPathExists = fs.pathExists;
+    realReadFile = fs.readFile;
+
+    pathExistsSpy = jest.spyOn(fs, 'pathExists').mockImplementation(async (targetPath) => {
+      if (targetPath.startsWith(tempRoot)) {
+        return realPathExists.call(fs, targetPath);
+      }
+
+      return false;
+    });
+
+    readFileSpy = jest.spyOn(fs, 'readFile').mockImplementation(async (targetPath, ...args) => {
+      if (targetPath.startsWith(tempRoot)) {
+        return realReadFile.call(fs, targetPath, ...args);
+      }
+
+      throw new Error(`Unexpected readFile access during test: ${targetPath}`);
+    });
+
+    const bridge = new BMADBridge({
+      bmadCorePath: path.join(tempRoot, 'missing-core'),
+      bmadV6Path: tempRoot,
+      llmClient: { chat: jest.fn() },
+    });
+
+    const config = await bridge.initialize();
+
+    expect(bridge.getEnvironmentInfo().mode).toBe('v6-modules');
+
+    const envInfo = bridge.getEnvironmentInfo();
+    expect(envInfo.root).toBe(tempRoot);
+    expect(envInfo.modulesRoot).toBe(path.join(tempRoot, 'src', 'modules'));
+    expect(envInfo.catalog).toMatchObject({
+      moduleCount: 1,
+      agents: 1,
+      templates: 1,
+      tasks: 0,
+      checklists: 0,
+      data: 0,
+    });
+
+    expect(config.modules).toMatchObject(envInfo.catalog);
+
+    const agent = await bridge.loadAgent('alpha/alpha-agent');
+    expect(agent).toMatchObject({
+      moduleId: 'alpha',
+      id: 'alpha-agent',
+    });
+    expect(agent.content).toContain('Sample agent body');
+
+    const template = await bridge.loadTemplate('alpha/alpha-template');
+    expect(template).toContain('Hello {{name}}!');
+
+    expect(pathExistsSpy).toHaveBeenCalledWith(path.join(tempRoot, 'missing-core'));
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest test that creates a temporary V6-style workspace and initializes BMADBridge with it
- stub filesystem helpers to isolate the workspace and verify loader-backed agent and template access

## Testing
- npm test -- --runTestsByPath test/bmad-bridge.v6-mode.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df8c2e8cc88326a2c9f609fc5c4037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a comprehensive unit test suite for V6 mode detection and initialization.
  - Verifies correct environment exposure (workspace root, modules root, catalog) and module loading behavior for agents and templates.
  - Confirms core path checks and proper delegation to the V6 loader.
  - Improves reliability and confidence for V6 workspaces. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->