### PR TITLE
Add tests for probeInvisibleModule compatibility probing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,7 +86,7 @@ export default [
 
   // Jest test files
   {
-    files: ['test/**/*.js'],
+    files: ['test/**/*.js', 'test/**/*.ts'],
     languageOptions: {
       globals: {
         describe: 'readonly',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,6 +89,11 @@ export default [
     files: ['test/**/*.js', 'test/**/*.ts'],
     languageOptions: {
       globals: {
+        require: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        module: 'readonly',
+        exports: 'writable',
         describe: 'readonly',
         it: 'readonly',
         test: 'readonly',

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  transform: {
+    '^.+\\.ts$': '<rootDir>/test/support/ts-transformer.js',
+  },
+};

--- a/test/support/ts-transformer.js
+++ b/test/support/ts-transformer.js
@@ -34,6 +34,8 @@ module.exports = {
       .update('\0', 'utf8')
       .update(JSON.stringify(transformOptions))
       .update('\0', 'utf8')
+      .update(JSON.stringify(compilerOptions))
+      .update('\0', 'utf8')
       .digest('hex');
   },
 };

--- a/test/support/ts-transformer.js
+++ b/test/support/ts-transformer.js
@@ -1,0 +1,39 @@
+const crypto = require('node:crypto');
+// eslint-disable-next-line n/no-unpublished-require -- transformer runs in tests and depends on dev tooling
+const ts = require('typescript');
+
+const compilerOptions = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  moduleResolution: ts.ModuleResolutionKind.Node16,
+  esModuleInterop: true,
+  resolveJsonModule: true,
+  sourceMap: true,
+};
+
+module.exports = {
+  process(src, filename) {
+    const transpiled = ts.transpileModule(src, {
+      compilerOptions,
+      fileName: filename,
+    });
+
+    const code = transpiled.outputText.replaceAll('import.meta.url', '__filename');
+
+    return {
+      code,
+      map: transpiled.sourceMapText ?? null,
+    };
+  },
+  getCacheKey(sourceText, sourcePath, transformOptions) {
+    return crypto
+      .createHash('sha1')
+      .update(sourceText)
+      .update('\0', 'utf8')
+      .update(sourcePath)
+      .update('\0', 'utf8')
+      .update(JSON.stringify(transformOptions))
+      .update('\0', 'utf8')
+      .digest('hex');
+  },
+};

--- a/test/v6-module-probe.test.ts
+++ b/test/v6-module-probe.test.ts
@@ -55,10 +55,10 @@ describe('probeInvisibleModule', () => {
     });
 
     // Mock the dynamic import for the runtime module
-    const originalImport = global.import;
+    const originalImport = globalThis.import;
     const importSpy = jest.fn();
-    // @ts-expect-error - Mocking global import
-    global.import = jest.fn((modulePath) => {
+    // @ts-expect-error - Mocking global import (not in Node.js types)
+    globalThis.import = jest.fn((modulePath) => {
       importSpy(modulePath);
       if (modulePath === runtimeModulePath) {
         return Promise.resolve({ runOrchestratorServer: jest.fn() });
@@ -69,8 +69,8 @@ describe('probeInvisibleModule', () => {
     const result = await probeInvisibleModule({ workspaceRoot, legacyRoot });
 
     // Restore original import
-    // @ts-expect-error - Restoring global import
-    global.import = originalImport;
+    // @ts-expect-error - Restoring global import (not in Node.js types)
+    globalThis.import = originalImport;
 
     expect(existsSpy).toHaveBeenCalled();
     expect(requireMock).toHaveBeenCalledWith(legacyBridgePath);
@@ -122,10 +122,10 @@ describe('probeInvisibleModule', () => {
     const { probeInvisibleModule } = require(moduleUnderTestPath);
 
     // Mock the dynamic import for the runtime module to fail
-    const originalImport = global.import;
+    const originalImport = globalThis.import;
     const importSpy = jest.fn();
-    // @ts-expect-error - Mocking global import
-    global.import = jest.fn((modulePath) => {
+    // @ts-expect-error - Mocking global import (not in Node.js types)
+    globalThis.import = jest.fn((modulePath) => {
       importSpy(modulePath);
       if (modulePath === runtimeModulePath) {
         return Promise.reject(new Error('Cannot import runtime'));
@@ -136,8 +136,8 @@ describe('probeInvisibleModule', () => {
     const result = await probeInvisibleModule({ workspaceRoot, legacyRoot });
 
     // Restore original import
-    // @ts-expect-error - Restoring global import
-    global.import = originalImport;
+    // @ts-expect-error - Restoring global import (not in Node.js types)
+    globalThis.import = originalImport;
 
     expect(requireMock).toHaveBeenCalledWith(legacyBridgePath);
     expect(requireMock).toHaveBeenCalledTimes(1);

--- a/test/v6-module-probe.test.ts
+++ b/test/v6-module-probe.test.ts
@@ -1,0 +1,125 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
+describe('probeInvisibleModule', () => {
+  const moduleUnderTestPath = path.resolve(__dirname, '../src/v6-poc/modules/invisible/module.ts');
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('reports warnings and notes when legacy assets can be probed successfully', async () => {
+    const workspaceRoot = '/tmp/workspace-success';
+    const legacyRoot = '/tmp/legacy-success';
+    const expectedModuleDir = path.join(workspaceRoot, 'src', 'modules', 'invisible');
+    const personaPath = path.join(legacyRoot, 'agents', 'invisible-orchestrator.md');
+    const agentsDir = path.join(workspaceRoot, 'src', 'modules', 'invisible', 'agents');
+    const runtimeModulePath = path.join(legacyRoot, 'src', 'mcp-server', 'runtime.ts');
+    const legacyBridgePath = path.join(legacyRoot, 'lib', 'bmad-bridge.js');
+
+    jest.resetModules();
+
+    const requireMock = jest.fn();
+    jest.doMock('node:module', () => ({
+      createRequire: jest.fn(() => requireMock),
+    }));
+
+    const existsSpy = jest.spyOn(fs, 'existsSync').mockImplementation((requestedPath) => {
+      if (requestedPath === expectedModuleDir) {
+        return true;
+      }
+      if (requestedPath === personaPath) {
+        return true;
+      }
+      if (requestedPath === agentsDir) {
+        return true;
+      }
+      return false;
+    });
+
+    const { probeInvisibleModule } = require(moduleUnderTestPath);
+
+    const initializeMock = jest.fn();
+    requireMock.mockImplementation((requestedPath) => {
+      if (requestedPath === legacyBridgePath) {
+        class MockBridge {
+          initialize() {
+            return initializeMock();
+          }
+        }
+        return { BMADBridge: MockBridge };
+      }
+      if (requestedPath === runtimeModulePath) {
+        return { runOrchestratorServer: jest.fn() };
+      }
+      throw new Error(`Unexpected require path: ${requestedPath}`);
+    });
+
+    const result = await probeInvisibleModule({ workspaceRoot, legacyRoot });
+
+    expect(existsSpy).toHaveBeenCalled();
+    expect(requireMock).toHaveBeenCalledWith(legacyBridgePath);
+    expect(requireMock).toHaveBeenCalledWith(runtimeModulePath);
+    expect(initializeMock).not.toHaveBeenCalled();
+    expect(result.blockers).toEqual([]);
+    expect(result.warnings).toEqual([
+      'BMADBridge loads via CommonJS require(); V6 default ESM bundler will need a compatibility shim or rewrite.',
+      'Legacy MCP runtime imports CommonJS hooks at execution time; V6 build graph may break lazy requires without loader hooks.',
+    ]);
+    expect(result.notes).toEqual([
+      `Found candidate module directory at ${expectedModuleDir}.`,
+      'Persona document located but requires relocation and renaming conventions for V6.',
+    ]);
+  });
+
+  test('surfaces blockers when V6 workspace cannot access legacy assets', async () => {
+    const workspaceRoot = '/tmp/workspace-failure';
+    const legacyRoot = '/tmp/legacy-failure';
+    const expectedModuleDir = path.join(workspaceRoot, 'src', 'modules', 'invisible');
+    const personaPath = path.join(legacyRoot, 'agents', 'invisible-orchestrator.md');
+    const runtimeModulePath = path.join(legacyRoot, 'src', 'mcp-server', 'runtime.ts');
+    const legacyBridgePath = path.join(legacyRoot, 'lib', 'bmad-bridge.js');
+
+    jest.resetModules();
+
+    const requireMock = jest.fn((requestedPath) => {
+      if (requestedPath === runtimeModulePath) {
+        throw new Error('Cannot import runtime');
+      }
+      if (requestedPath === legacyBridgePath) {
+        throw new Error('CommonJS module rejection');
+      }
+      throw new Error(`Unexpected require path: ${requestedPath}`);
+    });
+    jest.doMock('node:module', () => ({
+      createRequire: jest.fn(() => requireMock),
+    }));
+
+    jest.spyOn(fs, 'existsSync').mockImplementation((requestedPath) => {
+      if (requestedPath === expectedModuleDir) {
+        return false;
+      }
+      if (requestedPath === personaPath) {
+        return false;
+      }
+      return false;
+    });
+
+    const { probeInvisibleModule } = require(moduleUnderTestPath);
+
+    const result = await probeInvisibleModule({ workspaceRoot, legacyRoot });
+
+    expect(requireMock).toHaveBeenCalledWith(legacyBridgePath);
+    expect(requireMock).toHaveBeenCalledWith(runtimeModulePath);
+    expect(result.blockers).toEqual([
+      `Missing module slot: expected directory at ${expectedModuleDir}. V6 alpha currently ships only BMM/BMB/CIS modules, so invisible orchestration needs a new module registration point.`,
+      'Failed to require legacy BMAD bridge: CommonJS module rejection. V6 loaders refuse CommonJS modules without explicit compatibility wrappers.',
+      'Failed to import MCP runtime as ESM: Cannot import runtime. TypeScript compilation currently targets CommonJS paths, incompatible with V6\'s native ES build.',
+      `Invisible orchestrator persona missing at ${personaPath}.`,
+    ]);
+    expect(result.warnings).toEqual([]);
+    expect(result.notes).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest to transpile TypeScript files via a custom transformer so the probeInvisibleModule tests can require TypeScript sources
- add unit coverage for probeInvisibleModule that exercises successful and failing module, bridge, and runtime probing paths

## Testing
- npm test -- --runTestsByPath test/v6-module-probe.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df8c29200483268c372b1744d10acd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added tests covering module probing for both accessible and inaccessible legacy-asset scenarios, improving coverage and confidence in compatibility behavior.
- Chores
  - Enabled Jest to run TypeScript-based tests.
  - Added a custom TypeScript transformer to ensure stable test transpilation.
  - Updated lint/test patterns to include TypeScript test files and required globals for test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->