### PR TITLE
Fix MCP servers to resolve shared modules from package root

### DIFF
--- a/dist/codex/codex-server.d.ts
+++ b/dist/codex/codex-server.d.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-import { LLMClient } from "../../lib/llm-client.js";
 import { LaneKey } from "./runtime.js";
 import { OperationPolicyEnforcer } from "./operation-policy.js";
 import { StructuredLogger } from "./observability.js";
+type LLMClientModule = typeof import("../../lib/llm-client.js");
+type LLMClientCtor = LLMClientModule["LLMClient"];
+type LLMClientInstance = InstanceType<LLMClientCtor>;
 interface ModelRoute {
     provider: string;
     model: string;
@@ -28,7 +30,7 @@ export declare class CodexClient {
     private readonly logger;
     constructor(router: ModelRouter, approvalMode: boolean, autoApprove: boolean, approvedOps: Set<string>, policyEnforcer?: OperationPolicyEnforcer, logger?: StructuredLogger);
     static fromEnvironment(): CodexClient;
-    createLLMClient(lane?: LaneKey): LLMClient;
+    createLLMClient(lane?: LaneKey): LLMClientInstance;
     ensureOperationAllowed(operation: string, metadata?: Record<string, unknown>): Promise<void>;
     getLogger(): StructuredLogger;
     logStartup(): void;

--- a/dist/codex/codex-server.js
+++ b/dist/codex/codex-server.js
@@ -2,11 +2,12 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.CodexClient = void 0;
-const llm_client_js_1 = require('../../lib/llm-client.js');
 const runtime_js_1 = require('./runtime.js');
 const operation_policy_js_1 = require('./operation-policy.js');
 const codex_config_js_1 = require('./codex-config.js');
 const observability_js_1 = require('./observability.js');
+const lib_resolver_js_1 = require('./lib-resolver.js');
+const { LLMClient } = (0, lib_resolver_js_1.requireLibModule)('llm-client.js');
 function parseBoolean(value, defaultValue = false) {
   if (value == null) {
     return defaultValue;
@@ -155,10 +156,7 @@ class CodexClient {
     if (!this.llmCache.has(key)) {
       const stopTimer = this.logger.startTimer();
       const route = this.router.resolve(lane);
-      this.llmCache.set(
-        key,
-        new llm_client_js_1.LLMClient({ provider: route.provider, model: route.model }),
-      );
+      this.llmCache.set(key, new LLMClient({ provider: route.provider, model: route.model }));
       const durationMs = stopTimer();
       this.logger.info('llm_client_initialized', {
         operation: 'create_llm_client',

--- a/dist/codex/lib-resolver.d.ts
+++ b/dist/codex/lib-resolver.d.ts
@@ -1,0 +1,5 @@
+export declare function resolveFromPackageRoot(...segments: string[]): string;
+export declare function resolveLibPath(moduleName: string): string;
+export declare function importLibModule<TModule = unknown>(moduleName: string): Promise<TModule>;
+export declare function requireLibModule<TModule = unknown>(moduleName: string): TModule;
+export declare function importFromPackageRoot<TModule = unknown>(...segments: string[]): Promise<TModule>;

--- a/dist/codex/lib-resolver.js
+++ b/dist/codex/lib-resolver.js
@@ -1,0 +1,100 @@
+'use strict';
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (!desc || ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+          desc = {
+            enumerable: true,
+            get: function () {
+              return m[k];
+            },
+          };
+        }
+        Object.defineProperty(o, k2, desc);
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+      });
+var __setModuleDefault =
+  (this && this.__setModuleDefault) ||
+  (Object.create
+    ? function (o, v) {
+        Object.defineProperty(o, 'default', { enumerable: true, value: v });
+      }
+    : function (o, v) {
+        o['default'] = v;
+      });
+var __importStar =
+  (this && this.__importStar) ||
+  (function () {
+    var ownKeys = function (o) {
+      ownKeys =
+        Object.getOwnPropertyNames ||
+        function (o) {
+          var ar = [];
+          for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+          return ar;
+        };
+      return ownKeys(o);
+    };
+    return function (mod) {
+      if (mod && mod.__esModule) return mod;
+      var result = {};
+      if (mod != null)
+        for (var k = ownKeys(mod), i = 0; i < k.length; i++)
+          if (k[i] !== 'default') __createBinding(result, mod, k[i]);
+      __setModuleDefault(result, mod);
+      return result;
+    };
+  })();
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.resolveFromPackageRoot = resolveFromPackageRoot;
+exports.resolveLibPath = resolveLibPath;
+exports.importLibModule = importLibModule;
+exports.requireLibModule = requireLibModule;
+exports.importFromPackageRoot = importFromPackageRoot;
+const node_fs_1 = require('node:fs');
+const path = __importStar(require('node:path'));
+const node_url_1 = require('node:url');
+const node_module_1 = require('node:module');
+const requireFromMeta = (0, node_module_1.createRequire)(__filename);
+let cachedPackageRoot;
+function getPackageRoot() {
+  if (cachedPackageRoot) {
+    return cachedPackageRoot;
+  }
+  let current = __dirname;
+  while (true) {
+    if ((0, node_fs_1.existsSync)(path.join(current, 'package.json'))) {
+      cachedPackageRoot = current;
+      return cachedPackageRoot;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(`Unable to locate package root from ${__dirname}`);
+    }
+    current = parent;
+  }
+}
+function resolveFromPackageRoot(...segments) {
+  return path.resolve(getPackageRoot(), ...segments);
+}
+function resolveLibPath(moduleName) {
+  return resolveFromPackageRoot('lib', moduleName);
+}
+async function importLibModule(moduleName) {
+  const modulePath = resolveLibPath(moduleName);
+  return import((0, node_url_1.pathToFileURL)(modulePath).href);
+}
+function requireLibModule(moduleName) {
+  const modulePath = resolveLibPath(moduleName);
+  return requireFromMeta(modulePath);
+}
+async function importFromPackageRoot(...segments) {
+  const modulePath = resolveFromPackageRoot(...segments);
+  return import((0, node_url_1.pathToFileURL)(modulePath).href);
+}

--- a/dist/codex/runtime.js
+++ b/dist/codex/runtime.js
@@ -1,64 +1,12 @@
 'use strict';
-var __createBinding =
-  (this && this.__createBinding) ||
-  (Object.create
-    ? function (o, m, k, k2) {
-        if (k2 === undefined) k2 = k;
-        var desc = Object.getOwnPropertyDescriptor(m, k);
-        if (!desc || ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-          desc = {
-            enumerable: true,
-            get: function () {
-              return m[k];
-            },
-          };
-        }
-        Object.defineProperty(o, k2, desc);
-      }
-    : function (o, m, k, k2) {
-        if (k2 === undefined) k2 = k;
-        o[k2] = m[k];
-      });
-var __setModuleDefault =
-  (this && this.__setModuleDefault) ||
-  (Object.create
-    ? function (o, v) {
-        Object.defineProperty(o, 'default', { enumerable: true, value: v });
-      }
-    : function (o, v) {
-        o['default'] = v;
-      });
-var __importStar =
-  (this && this.__importStar) ||
-  (function () {
-    var ownKeys = function (o) {
-      ownKeys =
-        Object.getOwnPropertyNames ||
-        function (o) {
-          var ar = [];
-          for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-          return ar;
-        };
-      return ownKeys(o);
-    };
-    return function (mod) {
-      if (mod && mod.__esModule) return mod;
-      var result = {};
-      if (mod != null)
-        for (var k = ownKeys(mod), i = 0; i < k.length; i++)
-          if (k[i] !== 'default') __createBinding(result, mod, k[i]);
-      __setModuleDefault(result, mod);
-      return result;
-    };
-  })();
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.runOrchestratorServer = runOrchestratorServer;
 const index_js_1 = require('@modelcontextprotocol/sdk/server/index.js');
 const stdio_js_1 = require('@modelcontextprotocol/sdk/server/stdio.js');
 const types_js_1 = require('@modelcontextprotocol/sdk/types.js');
-const path = __importStar(require('node:path'));
-const auto_commands_js_1 = require('../../lib/auto-commands.js');
 const observability_js_1 = require('./observability.js');
+const lib_resolver_js_1 = require('./lib-resolver.js');
+const { executeAutoCommand } = (0, lib_resolver_js_1.requireLibModule)('auto-commands.js');
 /**
  * Builds a structured parse error for agent trigger failures.
  *
@@ -275,7 +223,7 @@ const REVIEW_CHECKPOINTS = {
 const STORY_CONTEXT_VALIDATION_CHECKPOINT = 'story_context_validation';
 const REVIEW_CHECKPOINT_NAMES = Object.freeze(Object.keys(REVIEW_CHECKPOINTS));
 async function getDefaultLLMClientCtor() {
-  const mod = await import('../../lib/llm-client.js');
+  const mod = await (0, lib_resolver_js_1.importLibModule)('llm-client.js');
   return mod.LLMClient;
 }
 async function runOrchestratorServer(options = {}) {
@@ -325,34 +273,42 @@ async function runOrchestratorServer(options = {}) {
     validationLane: 'review',
   };
   async function loadDependencies() {
-    const libPath = path.join(__dirname, '..', '..', 'lib');
-    const hooksPath = path.join(__dirname, '..', '..', 'hooks');
     if (!ProjectState) {
-      ({ ProjectState } = await import(path.join(libPath, 'project-state.js')));
+      ({ ProjectState } = await (0, lib_resolver_js_1.importLibModule)('project-state.js'));
     }
     if (!BMADBridge) {
-      ({ BMADBridge } = await import(path.join(libPath, 'bmad-bridge.js')));
+      ({ BMADBridge } = await (0, lib_resolver_js_1.importLibModule)('bmad-bridge.js'));
     }
     if (!DeliverableGenerator) {
-      ({ DeliverableGenerator } = await import(path.join(libPath, 'deliverable-generator.js')));
+      ({ DeliverableGenerator } = await (0, lib_resolver_js_1.importLibModule)(
+        'deliverable-generator.js',
+      ));
     }
     if (!BrownfieldAnalyzer) {
-      ({ BrownfieldAnalyzer } = await import(path.join(libPath, 'brownfield-analyzer.js')));
+      ({ BrownfieldAnalyzer } = await (0, lib_resolver_js_1.importLibModule)(
+        'brownfield-analyzer.js',
+      ));
     }
     if (!QuickLane) {
-      ({ QuickLane } = await import(path.join(libPath, 'quick-lane.js')));
+      ({ QuickLane } = await (0, lib_resolver_js_1.importLibModule)('quick-lane.js'));
     }
     if (!LaneSelector) {
-      LaneSelector = await import(path.join(libPath, 'lane-selector.js'));
+      LaneSelector = await (0, lib_resolver_js_1.importLibModule)('lane-selector.js');
     }
     if (!phaseTransitionHooks) {
-      phaseTransitionHooks = await import(path.join(hooksPath, 'phase-transition.js'));
+      phaseTransitionHooks = await (0, lib_resolver_js_1.importFromPackageRoot)(
+        'hooks',
+        'phase-transition.js',
+      );
     }
     if (!contextPreservation) {
-      contextPreservation = await import(path.join(hooksPath, 'context-preservation.js'));
+      contextPreservation = await (0, lib_resolver_js_1.importFromPackageRoot)(
+        'hooks',
+        'context-preservation.js',
+      );
     }
     if (!storyContextValidator) {
-      const module = await import(path.join(libPath, 'story-context-validator.js'));
+      const module = await (0, lib_resolver_js_1.importLibModule)('story-context-validator.js');
       storyContextValidator = module?.default ?? module;
     }
   }
@@ -435,7 +391,7 @@ async function runOrchestratorServer(options = {}) {
           operation: 'execute_auto_command',
           command,
         });
-        return (0, auto_commands_js_1.executeAutoCommand)(command, context, bmadBridge);
+        return executeAutoCommand(command, context, bmadBridge);
       },
       updateProjectState: async (updates) => {
         await projectState.updateState(updates);

--- a/dist/mcp/src/mcp-server/codex-server.d.ts
+++ b/dist/mcp/src/mcp-server/codex-server.d.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-import { LLMClient } from "../../lib/llm-client.js";
 import { LaneKey } from "./runtime.js";
 import { OperationPolicyEnforcer } from "./operation-policy.js";
 import { StructuredLogger } from "./observability.js";
+type LLMClientModule = typeof import("../../lib/llm-client.js");
+type LLMClientCtor = LLMClientModule["LLMClient"];
+type LLMClientInstance = InstanceType<LLMClientCtor>;
 interface ModelRoute {
     provider: string;
     model: string;
@@ -28,7 +30,7 @@ export declare class CodexClient {
     private readonly logger;
     constructor(router: ModelRouter, approvalMode: boolean, autoApprove: boolean, approvedOps: Set<string>, policyEnforcer?: OperationPolicyEnforcer, logger?: StructuredLogger);
     static fromEnvironment(): CodexClient;
-    createLLMClient(lane?: LaneKey): LLMClient;
+    createLLMClient(lane?: LaneKey): LLMClientInstance;
     ensureOperationAllowed(operation: string, metadata?: Record<string, unknown>): Promise<void>;
     getLogger(): StructuredLogger;
     logStartup(): void;

--- a/dist/mcp/src/mcp-server/codex-server.js
+++ b/dist/mcp/src/mcp-server/codex-server.js
@@ -2,11 +2,12 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.CodexClient = void 0;
-const llm_client_js_1 = require('../../lib/llm-client.js');
 const runtime_js_1 = require('./runtime.js');
 const operation_policy_js_1 = require('./operation-policy.js');
 const codex_config_js_1 = require('./codex-config.js');
 const observability_js_1 = require('./observability.js');
+const lib_resolver_js_1 = require('./lib-resolver.js');
+const { LLMClient } = (0, lib_resolver_js_1.requireLibModule)('llm-client.js');
 function parseBoolean(value, defaultValue = false) {
   if (value == null) {
     return defaultValue;
@@ -155,10 +156,7 @@ class CodexClient {
     if (!this.llmCache.has(key)) {
       const stopTimer = this.logger.startTimer();
       const route = this.router.resolve(lane);
-      this.llmCache.set(
-        key,
-        new llm_client_js_1.LLMClient({ provider: route.provider, model: route.model }),
-      );
+      this.llmCache.set(key, new LLMClient({ provider: route.provider, model: route.model }));
       const durationMs = stopTimer();
       this.logger.info('llm_client_initialized', {
         operation: 'create_llm_client',

--- a/dist/mcp/src/mcp-server/lib-resolver.d.ts
+++ b/dist/mcp/src/mcp-server/lib-resolver.d.ts
@@ -1,0 +1,5 @@
+export declare function resolveFromPackageRoot(...segments: string[]): string;
+export declare function resolveLibPath(moduleName: string): string;
+export declare function importLibModule<TModule = unknown>(moduleName: string): Promise<TModule>;
+export declare function requireLibModule<TModule = unknown>(moduleName: string): TModule;
+export declare function importFromPackageRoot<TModule = unknown>(...segments: string[]): Promise<TModule>;

--- a/dist/mcp/src/mcp-server/lib-resolver.js
+++ b/dist/mcp/src/mcp-server/lib-resolver.js
@@ -1,0 +1,100 @@
+'use strict';
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (!desc || ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+          desc = {
+            enumerable: true,
+            get: function () {
+              return m[k];
+            },
+          };
+        }
+        Object.defineProperty(o, k2, desc);
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+      });
+var __setModuleDefault =
+  (this && this.__setModuleDefault) ||
+  (Object.create
+    ? function (o, v) {
+        Object.defineProperty(o, 'default', { enumerable: true, value: v });
+      }
+    : function (o, v) {
+        o['default'] = v;
+      });
+var __importStar =
+  (this && this.__importStar) ||
+  (function () {
+    var ownKeys = function (o) {
+      ownKeys =
+        Object.getOwnPropertyNames ||
+        function (o) {
+          var ar = [];
+          for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+          return ar;
+        };
+      return ownKeys(o);
+    };
+    return function (mod) {
+      if (mod && mod.__esModule) return mod;
+      var result = {};
+      if (mod != null)
+        for (var k = ownKeys(mod), i = 0; i < k.length; i++)
+          if (k[i] !== 'default') __createBinding(result, mod, k[i]);
+      __setModuleDefault(result, mod);
+      return result;
+    };
+  })();
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.resolveFromPackageRoot = resolveFromPackageRoot;
+exports.resolveLibPath = resolveLibPath;
+exports.importLibModule = importLibModule;
+exports.requireLibModule = requireLibModule;
+exports.importFromPackageRoot = importFromPackageRoot;
+const node_fs_1 = require('node:fs');
+const path = __importStar(require('node:path'));
+const node_url_1 = require('node:url');
+const node_module_1 = require('node:module');
+const requireFromMeta = (0, node_module_1.createRequire)(__filename);
+let cachedPackageRoot;
+function getPackageRoot() {
+  if (cachedPackageRoot) {
+    return cachedPackageRoot;
+  }
+  let current = __dirname;
+  while (true) {
+    if ((0, node_fs_1.existsSync)(path.join(current, 'package.json'))) {
+      cachedPackageRoot = current;
+      return cachedPackageRoot;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(`Unable to locate package root from ${__dirname}`);
+    }
+    current = parent;
+  }
+}
+function resolveFromPackageRoot(...segments) {
+  return path.resolve(getPackageRoot(), ...segments);
+}
+function resolveLibPath(moduleName) {
+  return resolveFromPackageRoot('lib', moduleName);
+}
+async function importLibModule(moduleName) {
+  const modulePath = resolveLibPath(moduleName);
+  return import((0, node_url_1.pathToFileURL)(modulePath).href);
+}
+function requireLibModule(moduleName) {
+  const modulePath = resolveLibPath(moduleName);
+  return requireFromMeta(modulePath);
+}
+async function importFromPackageRoot(...segments) {
+  const modulePath = resolveFromPackageRoot(...segments);
+  return import((0, node_url_1.pathToFileURL)(modulePath).href);
+}

--- a/dist/mcp/src/mcp-server/runtime.js
+++ b/dist/mcp/src/mcp-server/runtime.js
@@ -1,64 +1,12 @@
 'use strict';
-var __createBinding =
-  (this && this.__createBinding) ||
-  (Object.create
-    ? function (o, m, k, k2) {
-        if (k2 === undefined) k2 = k;
-        var desc = Object.getOwnPropertyDescriptor(m, k);
-        if (!desc || ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-          desc = {
-            enumerable: true,
-            get: function () {
-              return m[k];
-            },
-          };
-        }
-        Object.defineProperty(o, k2, desc);
-      }
-    : function (o, m, k, k2) {
-        if (k2 === undefined) k2 = k;
-        o[k2] = m[k];
-      });
-var __setModuleDefault =
-  (this && this.__setModuleDefault) ||
-  (Object.create
-    ? function (o, v) {
-        Object.defineProperty(o, 'default', { enumerable: true, value: v });
-      }
-    : function (o, v) {
-        o['default'] = v;
-      });
-var __importStar =
-  (this && this.__importStar) ||
-  (function () {
-    var ownKeys = function (o) {
-      ownKeys =
-        Object.getOwnPropertyNames ||
-        function (o) {
-          var ar = [];
-          for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-          return ar;
-        };
-      return ownKeys(o);
-    };
-    return function (mod) {
-      if (mod && mod.__esModule) return mod;
-      var result = {};
-      if (mod != null)
-        for (var k = ownKeys(mod), i = 0; i < k.length; i++)
-          if (k[i] !== 'default') __createBinding(result, mod, k[i]);
-      __setModuleDefault(result, mod);
-      return result;
-    };
-  })();
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.runOrchestratorServer = runOrchestratorServer;
 const index_js_1 = require('@modelcontextprotocol/sdk/server/index.js');
 const stdio_js_1 = require('@modelcontextprotocol/sdk/server/stdio.js');
 const types_js_1 = require('@modelcontextprotocol/sdk/types.js');
-const path = __importStar(require('node:path'));
-const auto_commands_js_1 = require('../../lib/auto-commands.js');
 const observability_js_1 = require('./observability.js');
+const lib_resolver_js_1 = require('./lib-resolver.js');
+const { executeAutoCommand } = (0, lib_resolver_js_1.requireLibModule)('auto-commands.js');
 /**
  * Builds a structured parse error for agent trigger failures.
  *
@@ -275,7 +223,7 @@ const REVIEW_CHECKPOINTS = {
 const STORY_CONTEXT_VALIDATION_CHECKPOINT = 'story_context_validation';
 const REVIEW_CHECKPOINT_NAMES = Object.freeze(Object.keys(REVIEW_CHECKPOINTS));
 async function getDefaultLLMClientCtor() {
-  const mod = await import('../../lib/llm-client.js');
+  const mod = await (0, lib_resolver_js_1.importLibModule)('llm-client.js');
   return mod.LLMClient;
 }
 async function runOrchestratorServer(options = {}) {
@@ -325,34 +273,42 @@ async function runOrchestratorServer(options = {}) {
     validationLane: 'review',
   };
   async function loadDependencies() {
-    const libPath = path.join(__dirname, '..', '..', 'lib');
-    const hooksPath = path.join(__dirname, '..', '..', 'hooks');
     if (!ProjectState) {
-      ({ ProjectState } = await import(path.join(libPath, 'project-state.js')));
+      ({ ProjectState } = await (0, lib_resolver_js_1.importLibModule)('project-state.js'));
     }
     if (!BMADBridge) {
-      ({ BMADBridge } = await import(path.join(libPath, 'bmad-bridge.js')));
+      ({ BMADBridge } = await (0, lib_resolver_js_1.importLibModule)('bmad-bridge.js'));
     }
     if (!DeliverableGenerator) {
-      ({ DeliverableGenerator } = await import(path.join(libPath, 'deliverable-generator.js')));
+      ({ DeliverableGenerator } = await (0, lib_resolver_js_1.importLibModule)(
+        'deliverable-generator.js',
+      ));
     }
     if (!BrownfieldAnalyzer) {
-      ({ BrownfieldAnalyzer } = await import(path.join(libPath, 'brownfield-analyzer.js')));
+      ({ BrownfieldAnalyzer } = await (0, lib_resolver_js_1.importLibModule)(
+        'brownfield-analyzer.js',
+      ));
     }
     if (!QuickLane) {
-      ({ QuickLane } = await import(path.join(libPath, 'quick-lane.js')));
+      ({ QuickLane } = await (0, lib_resolver_js_1.importLibModule)('quick-lane.js'));
     }
     if (!LaneSelector) {
-      LaneSelector = await import(path.join(libPath, 'lane-selector.js'));
+      LaneSelector = await (0, lib_resolver_js_1.importLibModule)('lane-selector.js');
     }
     if (!phaseTransitionHooks) {
-      phaseTransitionHooks = await import(path.join(hooksPath, 'phase-transition.js'));
+      phaseTransitionHooks = await (0, lib_resolver_js_1.importFromPackageRoot)(
+        'hooks',
+        'phase-transition.js',
+      );
     }
     if (!contextPreservation) {
-      contextPreservation = await import(path.join(hooksPath, 'context-preservation.js'));
+      contextPreservation = await (0, lib_resolver_js_1.importFromPackageRoot)(
+        'hooks',
+        'context-preservation.js',
+      );
     }
     if (!storyContextValidator) {
-      const module = await import(path.join(libPath, 'story-context-validator.js'));
+      const module = await (0, lib_resolver_js_1.importLibModule)('story-context-validator.js');
       storyContextValidator = module?.default ?? module;
     }
   }
@@ -435,7 +391,7 @@ async function runOrchestratorServer(options = {}) {
           operation: 'execute_auto_command',
           command,
         });
-        return (0, auto_commands_js_1.executeAutoCommand)(command, context, bmadBridge);
+        return executeAutoCommand(command, context, bmadBridge);
       },
       updateProjectState: async (updates) => {
         await projectState.updateState(updates);

--- a/src/mcp-server/lib-resolver.ts
+++ b/src/mcp-server/lib-resolver.ts
@@ -1,0 +1,54 @@
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+
+const requireFromMeta = createRequire(__filename);
+
+let cachedPackageRoot: string | undefined;
+
+function getPackageRoot(): string {
+  if (cachedPackageRoot) {
+    return cachedPackageRoot;
+  }
+
+  let current = __dirname;
+  while (true) {
+    if (existsSync(path.join(current, "package.json"))) {
+      cachedPackageRoot = current;
+      return cachedPackageRoot;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(`Unable to locate package root from ${__dirname}`);
+    }
+
+    current = parent;
+  }
+}
+
+export function resolveFromPackageRoot(...segments: string[]): string {
+  return path.resolve(getPackageRoot(), ...segments);
+}
+
+export function resolveLibPath(moduleName: string): string {
+  return resolveFromPackageRoot("lib", moduleName);
+}
+
+export async function importLibModule<TModule = unknown>(moduleName: string): Promise<TModule> {
+  const modulePath = resolveLibPath(moduleName);
+  return import(pathToFileURL(modulePath).href) as Promise<TModule>;
+}
+
+export function requireLibModule<TModule = unknown>(moduleName: string): TModule {
+  const modulePath = resolveLibPath(moduleName);
+  return requireFromMeta(modulePath) as TModule;
+}
+
+export async function importFromPackageRoot<TModule = unknown>(
+  ...segments: string[]
+): Promise<TModule> {
+  const modulePath = resolveFromPackageRoot(...segments);
+  return import(pathToFileURL(modulePath).href) as Promise<TModule>;
+}


### PR DESCRIPTION
## Summary
- add a reusable resolver that locates the package root before importing shared MCP libraries
- update the MCP runtime and Codex server to load shared and dynamic modules through the resolver
- regenerate the compiled MCP and Codex artifacts after adjusting the import paths

## Testing
- npm run build:mcp
- node dist/mcp/mcp/server.js
- node dist/codex/codex-server.js

------
https://chatgpt.com/codex/tasks/task_e_68df9776a49083268ec2f7284f2409e1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced error reporting for agent parsing failures, now including agent ID, message, snippet, raw response, guidance, cause details, and optional context metadata to aid troubleshooting.

- Refactor
  - Switched to dynamic module resolution and runtime loading for core components to improve flexibility and resilience.
  - Streamlined initialization and caching flows without altering expected behavior for most users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->