### PR TITLE
Update docs for optional MCP servers and shadcn integration

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -30,6 +30,11 @@ Done! The command automatically:
 - Installs all dependencies
 - Launches the selected chat interface
 
+If you opt into the bundled shadcn UI helpers, the installer writes
+`components.json` using the official shadcn schema so future component imports
+(`npx shadcn@latest add card`, etc.) know your Tailwind paths and alias
+configuration.
+
 > **💡 Tip**: Always use `@latest` to avoid npx cache issues on either flow!
 
 ### Option 1b: NPX Step-by-Step
@@ -86,6 +91,14 @@ npm run build:mcp
 # Start conversation (prompts for choice)
 npm run bmad
 ```
+
+> **MCP Config Formats**
+>
+> - `.claude/mcp-config.json` powers Claude Code. Optional `chrome-devtools` and
+>   `shadcn` servers are present but disabled until you install them.
+> - `~/.codex/config.toml` powers Codex CLI. The same servers appear as TOML
+>   tables (`[mcp_servers.chrome_devtools]`, `[mcp_servers.shadcn]`) with
+>   `auto_start = false` by default.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ That's it! This command will:
 - Prompt you to choose between Claude, Codex, or OpenCode
 - Launch the selected chat interface
 
+> **UI Tooling Opt-in**: If you enable the optional shadcn UI helpers during the
+> wizard, the installer also writes a `components.json` in your project root.
+> This file follows the [shadcn/ui schema](https://ui.shadcn.com/docs/installation)
+> (`style`, `tailwind`, `aliases`, etc.) so downstream tooling like
+> `npx shadcn@latest add button` can pick up your preferences without extra
+> prompts.
+
 > **💡 Tip**: Always use `@latest` to ensure you get the newest version!
 
 #### Option 1b: NPX Step-by-Step
@@ -124,10 +131,22 @@ npm run bmad
 Interactive installs now auto-provision Codex CLI so you can run `codex` immediately after setup:
 
 - Generates/updates `AGENTS.md` with BMAD agent context for Codex memory.
-- Ensures `~/.codex/config.toml` exists with the `bmad_invisible` MCP server entry.
+- Ensures `~/.codex/config.toml` exists with the `bmad_invisible` MCP server
+  entry plus optional helpers for `chrome-devtools` and `shadcn` (disabled by
+  default until you install them).
 - Applies sensible defaults (`GPT-5-Codex` model, medium reasoning, automatic approvals) unless you have overrides.
 
 Non-interactive environments (like CI) skip the global config step, but you can review and customize the defaults via [`codex-config.toml.example`](./codex-config.toml.example).
+
+> **MCP Config Formats at a Glance**
+>
+> - **Claude / Claude Code** reads `.claude/mcp-config.json`. Entries are JSON
+>   objects keyed by server name, and optional servers such as
+>   `chrome-devtools` and `shadcn` simply set `disabled: true` until you toggle
+>   them on.
+> - **Codex CLI** reads `~/.codex/config.toml`. Each MCP server is declared in a
+>   TOML table (`[mcp_servers.bmad_invisible]`, `[mcp_servers.chrome_devtools]`,
+>   etc.) with `auto_start` flags mirroring the JSON `disabled` switches.
 
 ## 📖 How It Works
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -31,6 +31,11 @@ npm install
 npm run bmad:chat
 ```
 
+> **UI Toolkit Opt-in**: When you include the optional shadcn UI helpers, the
+> installer generates a `components.json` at the project root following the
+> shadcn schema so the `shadcn` CLI can locate your Tailwind and alias settings
+> during component installs.
+
 ### For Local Development
 
 ```bash
@@ -204,15 +209,25 @@ The MCP config at `.claude/mcp-config.json` works with:
 - Claude Code (CLI and Desktop)
 - Any MCP-compatible IDE
 
+> Claude uses a JSON object keyed by MCP server names. Optional entries for
+> `chrome-devtools` and `shadcn` are shipped disabled so you can flip them on by
+> changing `"disabled": false` after installing the corresponding servers.
+
 ### Codex CLI Defaults
 
 When you include Codex CLI during installation, the wizard now also prepares your global configuration:
 
 - Creates `~/.codex/config.toml` if it is missing.
-- Adds the `bmad_invisible` MCP server pointing to `npx bmad-invisible mcp`.
+- Adds the `bmad_invisible` MCP server pointing to `npx bmad-invisible mcp` and
+  stubs for optional `chrome-devtools` and `shadcn` integrations (with
+  `auto_start = false`).
 - Sets default Codex preferences (`GPT-5-Codex`, medium reasoning, automatic approvals) without overwriting existing overrides.
 
 This step is skipped automatically in non-interactive environments. See [`codex-config.toml.example`](./codex-config.toml.example) for the full TOML structure you can tailor afterwards.
+
+> Codex stores the MCP list in TOML tables (`[mcp_servers.<name>]`). Toggle the
+> optional helpers by switching `auto_start` to `true` once the external server
+> binaries are available locally.
 
 ### Automatic CLI Provisioning
 

--- a/codex-config.toml.example
+++ b/codex-config.toml.example
@@ -24,3 +24,19 @@ description = "BMAD Invisible Orchestrator MCP server"
 # EXAMPLE: BMAD_LOG_LEVEL = "debug"
 # BMAD_LOG_LEVEL = "debug"
 
+[mcp_servers.chrome_devtools]
+# Optional Chrome DevTools recorder MCP server (install package separately).
+type = "command"
+command = "npx"
+args = ["@modelcontextprotocol/server-chrome-devtools@latest"]
+auto_start = false
+description = "Chrome DevTools MCP helper (disabled until installed)"
+
+[mcp_servers.shadcn]
+# Optional shadcn UI MCP helper exposed by the shadcn CLI.
+type = "command"
+command = "npx"
+args = ["@shadcn/ui-cli@latest", "mcp"]
+auto_start = false
+description = "shadcn UI MCP helper (pairs with generated components.json)"
+

--- a/docs/codex-config.sample.toml
+++ b/docs/codex-config.sample.toml
@@ -16,3 +16,23 @@ description = "BMAD Invisible MCP server for orchestrating BMAD agents."
 displayName = "BMAD Invisible MCP"
 name = "bmad-mcp"
 transport = "stdio"
+
+[[mcp.servers]]
+args = ["@modelcontextprotocol/server-chrome-devtools@latest"]
+autoApprove = false
+autoStart = false
+command = "npx"
+description = "Optional Chrome DevTools recorder MCP server."
+displayName = "Chrome DevTools MCP"
+name = "chrome-devtools"
+transport = "stdio"
+
+[[mcp.servers]]
+args = ["@shadcn/ui-cli@latest", "mcp"]
+autoApprove = false
+autoStart = false
+command = "npx"
+description = "Optional shadcn UI MCP helper (works with generated components.json)."
+displayName = "shadcn UI MCP"
+name = "shadcn"
+transport = "stdio"

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -259,10 +259,16 @@ BMAD integrates with OpenAI Codex via `AGENTS.md` and committed core agent files
     - Agent Directory (Title, ID, When To Use)
     - Detailed per‑agent sections with source path, when-to-use, activation phrasing, and YAML
     - Tasks with quick usage notes
+  - Optional shadcn UI support drops a `components.json` at the root using the
+    canonical schema (`style`, `tailwind`, `aliases`, `typescript`, etc.) so the
+    `shadcn` CLI can scaffold UI components without re-prompting you for
+    preferences.
   - If a `package.json` exists, helpful scripts are added:
     - `bmad:refresh`, `bmad:list`, `bmad:validate`
   - Global Codex CLI defaults are merged into `~/.codex/config.toml` (skipped automatically in CI/non-interactive runs).
     - Ensures BMAD's MCP server is registered and Codex approvals run in fully automated mode by default.
+    - Registers optional `chrome-devtools` and `shadcn` MCP helpers with
+      `autoStart = false` so you can enable them post-install.
     - Resulting snippet:
 
       ```toml
@@ -284,9 +290,31 @@ BMAD integrates with OpenAI Codex via `AGENTS.md` and committed core agent files
       displayName = "BMAD Invisible MCP"
       name = "bmad-mcp"
       transport = "stdio"
+
+      [[mcp.servers]]
+      args = ["@modelcontextprotocol/server-chrome-devtools@latest"]
+      autoApprove = false
+      autoStart = false
+      command = "npx"
+      description = "Optional Chrome DevTools recorder MCP server."
+      displayName = "Chrome DevTools MCP"
+      name = "chrome-devtools"
+      transport = "stdio"
+
+      [[mcp.servers]]
+      args = ["@shadcn/ui-cli@latest", "mcp"]
+      autoApprove = false
+      autoStart = false
+      command = "npx"
+      description = "Optional shadcn UI MCP helper."
+      displayName = "shadcn UI MCP"
+      name = "shadcn"
+      transport = "stdio"
       ```
 
     - A copy of this config lives in `docs/codex-config.sample.toml` for reference.
+    - Claude Code uses the JSON equivalent at `.claude/mcp-config.json`; optional
+      servers appear with `"disabled": true` until you flip them on.
 
 - Using Codex:
   - CLI: run `codex` in the project root and prompt naturally, e.g., “As dev, implement …”.

--- a/docs/v6-sandbox-codex-cli.md
+++ b/docs/v6-sandbox-codex-cli.md
@@ -24,7 +24,10 @@ The new defaults introduced in `lib/codex/config-manager` target the V6 CLI prof
 
 - Model: `GPT-5-Codex`
 - Automated approvals for both CLI tools and MCP server actions
-- MCP server command: `npx bmad-invisible mcp`
+- MCP servers:
+  - `bmad_invisible` → `npx bmad-invisible mcp`
+  - Optional `chrome-devtools` and `shadcn` helpers (declared with
+    `auto_start = false` until you install their binaries)
 
 To (re)generate the CLI config from the sandbox, run:
 
@@ -32,7 +35,7 @@ To (re)generate the CLI config from the sandbox, run:
 node -e "(async () => { const { ensureCodexConfig } = require('./lib/codex/config-manager.js'); const result = await ensureCodexConfig({ nonInteractive: false }); console.log('Codex config written to', result.configPath); })();"
 ```
 
-This writes/updates `~/.codex/config.toml` with the auto-approval profile and ensures the BMAD MCP server entry matches the compiled assets.
+This writes/updates `~/.codex/config.toml` with the auto-approval profile and ensures the BMAD MCP server entry matches the compiled assets, while stubbing the optional helpers so Claude/Chromium tooling can be toggled on later.
 
 ## 3. Representative Chat Session Simulations
 

--- a/mcp/bmad-config.json
+++ b/mcp/bmad-config.json
@@ -3,6 +3,16 @@
     "bmad-invisible": {
       "command": "node",
       "args": ["dist/mcp/mcp/server.js"]
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-chrome-devtools@latest"],
+      "disabled": true
+    },
+    "shadcn": {
+      "command": "npx",
+      "args": ["@shadcn/ui-cli@latest", "mcp"],
+      "disabled": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- document the optional chrome-devtools and shadcn MCP servers across the onboarding guides
- note the differing Claude JSON versus Codex TOML config formats and the new shadcn components.json generation
- refresh sample Codex and Claude configs to include disabled stubs for the helper servers

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68df9cee11488326b0d28bfd822debb2