### PR TITLE
Add default MCP servers and tests

### DIFF
--- a/lib/codex/config-manager.js
+++ b/lib/codex/config-manager.js
@@ -8,16 +8,38 @@ const path = require('node:path');
 const DEFAULT_MODEL = 'GPT-5-Codex';
 const DEFAULT_MANUAL_APPROVAL = false;
 const SERVER_NAME = 'bmad-mcp';
-const DEFAULT_SERVER = {
-  name: SERVER_NAME,
-  displayName: 'BMAD Invisible MCP',
-  description: 'BMAD Invisible MCP server for orchestrating BMAD agents.',
-  transport: 'stdio',
-  command: 'npx',
-  args: ['bmad-invisible', 'mcp'],
-  autoStart: true,
-  autoApprove: true,
-};
+const DEFAULT_SERVERS = [
+  {
+    name: SERVER_NAME,
+    displayName: 'BMAD Invisible MCP',
+    description: 'BMAD Invisible MCP server for orchestrating BMAD agents.',
+    transport: 'stdio',
+    command: 'npx',
+    args: ['bmad-invisible', 'mcp'],
+    autoStart: true,
+    autoApprove: true,
+  },
+  {
+    name: 'chrome-devtools',
+    displayName: 'Chrome DevTools MCP',
+    description: 'Chrome DevTools automation server for inspecting web apps.',
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-chrome-devtools'],
+    autoStart: false,
+    autoApprove: true,
+  },
+  {
+    name: 'shadcn',
+    displayName: 'shadcn/ui MCP',
+    description: 'shadcn/ui component scaffolding and documentation helper.',
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-shadcn'],
+    autoStart: false,
+    autoApprove: true,
+  },
+];
 /**
  * Strips inline comments from a TOML line while preserving # characters inside strings.
  * @param line - The TOML line to process
@@ -180,6 +202,14 @@ function isPlainObject(value) {
 }
 function hasOwn(target, key) {
   return Object.prototype.hasOwnProperty.call(target, key);
+}
+function getServerLookupKey(server) {
+  if (!server) {
+    return '';
+  }
+  const raw =
+    typeof server.name === 'string' ? server.name : typeof server.id === 'string' ? server.id : '';
+  return raw.toLowerCase();
 }
 function ensureObjectPath(root, pathSegments) {
   let current = root;
@@ -370,28 +400,23 @@ function mergeServers(existingServers) {
   var _a;
   const servers = Array.isArray(existingServers) ? [...existingServers] : [];
   const materialised = servers.filter((server) => isPlainObject(server));
-  const index = materialised.findIndex((server) => {
-    var _a, _b;
-    const name =
-      (_b =
-        (_a = server === null || server === void 0 ? void 0 : server.name) !== null && _a !== void 0
-          ? _a
-          : server === null || server === void 0
-            ? void 0
-            : server.id) !== null && _b !== void 0
-        ? _b
-        : '';
-    return typeof name === 'string' && name.toLowerCase() === SERVER_NAME.toLowerCase();
-  });
-  const canonical = { ...DEFAULT_SERVER };
-  if (index === -1) {
-    materialised.push(canonical);
-    return { servers: materialised, changed: true };
+  let changed = false;
+  for (const defaultServer of DEFAULT_SERVERS) {
+    const canonical = { ...defaultServer };
+    const lookupKey = getServerLookupKey(canonical);
+    const index = materialised.findIndex((server) => getServerLookupKey(server) === lookupKey);
+    if (index === -1) {
+      materialised.push({ ...canonical });
+      changed = true;
+      continue;
+    }
+    const existing = (_a = materialised[index]) !== null && _a !== void 0 ? _a : {};
+    const merged = { ...canonical, ...existing };
+    if (JSON.stringify(existing) !== JSON.stringify(merged)) {
+      materialised[index] = merged;
+      changed = true;
+    }
   }
-  const existing = (_a = materialised[index]) !== null && _a !== void 0 ? _a : {};
-  const merged = { ...canonical, ...existing };
-  const changed = JSON.stringify(existing) !== JSON.stringify(merged);
-  materialised[index] = merged;
   return { servers: materialised, changed };
 }
 function normaliseMcpConfig(mcp) {

--- a/mcp/bmad-config.json
+++ b/mcp/bmad-config.json
@@ -3,6 +3,14 @@
     "bmad-invisible": {
       "command": "node",
       "args": ["dist/mcp/mcp/server.js"]
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-chrome-devtools"]
+    },
+    "shadcn": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-shadcn"]
     }
   }
 }

--- a/test/config-manager.test.js
+++ b/test/config-manager.test.js
@@ -1,82 +1,106 @@
-// Mock the config-manager module since it's TypeScript
-// This is a placeholder test to document expected behavior
-describe('config-manager mergeServers', () => {
-  it('should preserve user customizations when merging server defaults', () => {
-    // Expected behavior:
-    // Given existing servers with user customizations:
-    const _existingServers = [
-      {
-        name: 'bmad-mcp',
-        autoStart: false, // User explicitly disabled
-        command: '/custom/path/to/npx', // User custom command
-        args: ['bmad-invisible', 'mcp'],
-      },
-    ];
+const fs = require('fs-extra');
+const os = require('node:os');
+const path = require('node:path');
 
-    // When mergeServers is called
-    // const { servers, changed } = mergeServers(existingServers);
+const { ensureCodexConfig } = require('../lib/codex/config-manager.js');
 
-    // Then user customizations should be preserved:
-    // expect(servers[0].autoStart).toBe(false); // User's value preserved
-    // expect(servers[0].command).toBe('/custom/path/to/npx'); // User's value preserved
-    // expect(servers[0].displayName).toBe('BMAD Invisible MCP'); // Default filled in
+const DEFAULT_SERVER_NAMES = ['bmad-mcp', 'chrome-devtools', 'shadcn'];
 
-    // This test documents the expected behavior.
-    // Actual implementation requires importing the TypeScript module.
-    expect(true).toBe(true);
+function normaliseServerName(server) {
+  const value = server?.name ?? server?.id ?? '';
+  return String(value).toLowerCase();
+}
+
+describe('ensureCodexConfig MCP server defaults', () => {
+  let tmpHome;
+  let homeSpy;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-config-test-'));
+    homeSpy = jest.spyOn(os, 'homedir').mockReturnValue(tmpHome);
   });
 
-  it('should add missing default keys without overwriting existing ones', () => {
-    // Expected behavior:
-    // User config with partial settings should get defaults for missing keys only
-    const _existingServers = [
-      {
-        name: 'bmad-mcp',
-        autoStart: false,
-        // Missing: displayName, description, transport, command, args, autoApprove
-      },
-    ];
-
-    // When merged:
-    // - autoStart should remain false (user's choice)
-    // - displayName should be added with default value
-    // - All other missing keys should be added with defaults
-
-    expect(true).toBe(true);
+  afterEach(async () => {
+    if (homeSpy) {
+      homeSpy.mockRestore();
+    }
+    if (tmpHome) {
+      await fs.remove(tmpHome);
+    }
   });
 
-  it('should handle case-insensitive server name matching', () => {
-    // Expected behavior:
-    // Server names should match case-insensitively
-    const _existingServers = [
-      {
-        name: 'BMAD-MCP', // Different case
-        autoStart: false,
-      },
-    ];
+  it('adds missing default servers exactly once and preserves manual approval flags', async () => {
+    const configDir = path.join(tmpHome, '.codex');
+    const configPath = path.join(configDir, 'config.toml');
 
-    // When merged, should find the existing server by case-insensitive name match
-    // expect(changed).toBe(true); // Because missing keys were added
-    // expect(servers).toHaveLength(1); // Should not create duplicate
+    const initialToml = `
+[mcp]
+require_manual_approval = true
+auto_approve = false
 
-    expect(true).toBe(true);
+[[mcp.servers]]
+name = "bmad-mcp"
+command = "/custom/path/to/npx"
+args = ["bmad-invisible", "mcp"]
+autoStart = false
+autoApprove = false
+
+[[mcp.servers]]
+name = "custom-server"
+command = "custom"
+args = ["--flag"]
+`;
+
+    await fs.outputFile(configPath, initialToml);
+
+    const result = await ensureCodexConfig({ nonInteractive: true });
+
+    expect(result.config.mcp.require_manual_approval).toBe(true);
+    expect(result.config.mcp.auto_approve).toBe(false);
+
+    const servers = result.config.mcp.servers ?? [];
+    const nameCounts = new Map();
+    for (const server of servers) {
+      const name = normaliseServerName(server);
+      nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
+    }
+
+    for (const expectedName of DEFAULT_SERVER_NAMES) {
+      expect(nameCounts.get(expectedName)).toBe(1);
+    }
+
+    const orchestrator = servers.find((server) => normaliseServerName(server) === 'bmad-mcp');
+    expect(orchestrator).toBeDefined();
+    expect(orchestrator.autoStart).toBe(false);
+    expect(orchestrator.autoApprove).toBe(false);
+    expect(orchestrator.command).toBe('/custom/path/to/npx');
+
+    const chrome = servers.find((server) => normaliseServerName(server) === 'chrome-devtools');
+    expect(chrome).toBeDefined();
+    expect(chrome.command).toBe('npx');
+    expect(chrome.args).toEqual(['-y', '@modelcontextprotocol/server-chrome-devtools']);
+
+    const shadcn = servers.find((server) => normaliseServerName(server) === 'shadcn');
+    expect(shadcn).toBeDefined();
+    expect(shadcn.command).toBe('npx');
+    expect(shadcn.args).toEqual(['-y', '@modelcontextprotocol/server-shadcn']);
   });
 
-  it('should add new server if not found in existing servers', () => {
-    // Expected behavior:
-    const _existingServers = [
-      {
-        name: 'other-mcp',
-        autoStart: true,
-      },
-    ];
+  it('writes default servers once when generating a fresh config', async () => {
+    const first = await ensureCodexConfig({ nonInteractive: true });
+    const firstNames = [];
+    for (const server of first.config.mcp.servers ?? []) {
+      firstNames.push(normaliseServerName(server));
+    }
 
-    // When merged:
-    // - Should add bmad-mcp server with all defaults
-    // - Should preserve existing other-mcp server
-    // expect(servers).toHaveLength(2);
-    // expect(servers[1].name).toBe('bmad-mcp');
+    expect(firstNames).toEqual(DEFAULT_SERVER_NAMES);
 
-    expect(true).toBe(true);
+    const second = await ensureCodexConfig({ nonInteractive: true });
+    const secondNames = [];
+    for (const server of second.config.mcp.servers ?? []) {
+      secondNames.push(normaliseServerName(server));
+    }
+
+    expect(secondNames).toEqual(DEFAULT_SERVER_NAMES);
   });
 });


### PR DESCRIPTION
## Summary
- add chrome-devtools and shadcn MCP server defaults to the shipped config and Codex config manager logic
- update mergeServers handling to seed all default servers while preserving user overrides across both TS/JS implementations
- add config-manager jest coverage to ensure defaults are written exactly once and manual approval flags persist

## Testing
- npm test -- config-manager.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df9ceb247483268f871b7406d6d1b0