### PR TITLE
Fix v6 bridge loader detection

### DIFF
--- a/lib/bmad-bridge.js
+++ b/lib/bmad-bridge.js
@@ -7,6 +7,7 @@ const fs = require('fs-extra');
 const path = require('node:path');
 const yaml = require('js-yaml');
 const { LLMClient } = require('./llm-client');
+const { V6ModuleLoader } = require('./v6-module-loader');
 const contextEnrichment = require('../hooks/context-enrichment');
 
 function deepMerge(target, source) {

--- a/test/bmad-bridge.v6-mode.test.js
+++ b/test/bmad-bridge.v6-mode.test.js
@@ -2,8 +2,6 @@ const fs = require('fs-extra');
 const os = require('node:os');
 const path = require('node:path');
 
-const { V6ModuleLoader } = require('../lib/v6-module-loader.js');
-globalThis.V6ModuleLoader = V6ModuleLoader;
 const { BMADBridge } = require('../lib/bmad-bridge.js');
 
 async function createV6Workspace() {


### PR DESCRIPTION
## Summary
- import the v6 module loader inside the BMAD bridge so v6 detection can instantiate it
- update the v6 bridge test to use the real module loader import instead of a global mutation

## Testing
- `npm test -- bmad-bridge.v6-mode.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68dfa1f0e0488326839de5dff27c44b4