### PR TITLE
Refine Codex runtime module resolution

### DIFF
--- a/dist/codex/runtime.js
+++ b/dist/codex/runtime.js
@@ -4,11 +4,6 @@ exports.runOrchestratorServer = runOrchestratorServer;
 const index_js_1 = require('@modelcontextprotocol/sdk/server/index.js');
 const stdio_js_1 = require('@modelcontextprotocol/sdk/server/stdio.js');
 const types_js_1 = require('@modelcontextprotocol/sdk/types.js');
-const path = __importStar(require('node:path'));
-const repositoryRoot = path.resolve(__dirname, '..', '..', '..', '..');
-const libDirectory = path.join(repositoryRoot, 'lib');
-const hooksDirectory = path.join(repositoryRoot, 'hooks');
-const auto_commands_js_1 = require(path.join(libDirectory, 'auto-commands.js'));
 const observability_js_1 = require('./observability.js');
 const lib_resolver_js_1 = require('./lib-resolver.js');
 const { executeAutoCommand } = (0, lib_resolver_js_1.requireLibModule)('auto-commands.js');
@@ -279,33 +274,41 @@ async function runOrchestratorServer(options = {}) {
   };
   async function loadDependencies() {
     if (!ProjectState) {
-      ({ ProjectState } = await import(path.join(libDirectory, 'project-state.js')));
+      ({ ProjectState } = await (0, lib_resolver_js_1.importLibModule)('project-state.js'));
     }
     if (!BMADBridge) {
-      ({ BMADBridge } = await import(path.join(libDirectory, 'bmad-bridge.js')));
+      ({ BMADBridge } = await (0, lib_resolver_js_1.importLibModule)('bmad-bridge.js'));
     }
     if (!DeliverableGenerator) {
-      ({ DeliverableGenerator } = await import(
-        path.join(libDirectory, 'deliverable-generator.js')
+      ({ DeliverableGenerator } = await (0, lib_resolver_js_1.importLibModule)(
+        'deliverable-generator.js',
       ));
     }
     if (!BrownfieldAnalyzer) {
-      ({ BrownfieldAnalyzer } = await import(path.join(libDirectory, 'brownfield-analyzer.js')));
+      ({ BrownfieldAnalyzer } = await (0, lib_resolver_js_1.importLibModule)(
+        'brownfield-analyzer.js',
+      ));
     }
     if (!QuickLane) {
-      ({ QuickLane } = await import(path.join(libDirectory, 'quick-lane.js')));
+      ({ QuickLane } = await (0, lib_resolver_js_1.importLibModule)('quick-lane.js'));
     }
     if (!LaneSelector) {
-      LaneSelector = await import(path.join(libDirectory, 'lane-selector.js'));
+      LaneSelector = await (0, lib_resolver_js_1.importLibModule)('lane-selector.js');
     }
     if (!phaseTransitionHooks) {
-      phaseTransitionHooks = await import(path.join(hooksDirectory, 'phase-transition.js'));
+      phaseTransitionHooks = await (0, lib_resolver_js_1.importFromPackageRoot)(
+        'hooks',
+        'phase-transition.js',
+      );
     }
     if (!contextPreservation) {
-      contextPreservation = await import(path.join(hooksDirectory, 'context-preservation.js'));
+      contextPreservation = await (0, lib_resolver_js_1.importFromPackageRoot)(
+        'hooks',
+        'context-preservation.js',
+      );
     }
     if (!storyContextValidator) {
-      const module = await import(path.join(libDirectory, 'story-context-validator.js'));
+      const module = await (0, lib_resolver_js_1.importLibModule)('story-context-validator.js');
       storyContextValidator = module?.default ?? module;
     }
   }

--- a/dist/mcp/src/mcp-server/runtime.js
+++ b/dist/mcp/src/mcp-server/runtime.js
@@ -4,11 +4,6 @@ exports.runOrchestratorServer = runOrchestratorServer;
 const index_js_1 = require('@modelcontextprotocol/sdk/server/index.js');
 const stdio_js_1 = require('@modelcontextprotocol/sdk/server/stdio.js');
 const types_js_1 = require('@modelcontextprotocol/sdk/types.js');
-const path = __importStar(require('node:path'));
-const repositoryRoot = path.resolve(__dirname, '..', '..', '..', '..');
-const libDirectory = path.join(repositoryRoot, 'lib');
-const hooksDirectory = path.join(repositoryRoot, 'hooks');
-const auto_commands_js_1 = require(path.join(libDirectory, 'auto-commands.js'));
 const observability_js_1 = require('./observability.js');
 const lib_resolver_js_1 = require('./lib-resolver.js');
 const { executeAutoCommand } = (0, lib_resolver_js_1.requireLibModule)('auto-commands.js');
@@ -279,33 +274,41 @@ async function runOrchestratorServer(options = {}) {
   };
   async function loadDependencies() {
     if (!ProjectState) {
-      ({ ProjectState } = await import(path.join(libDirectory, 'project-state.js')));
+      ({ ProjectState } = await (0, lib_resolver_js_1.importLibModule)('project-state.js'));
     }
     if (!BMADBridge) {
-      ({ BMADBridge } = await import(path.join(libDirectory, 'bmad-bridge.js')));
+      ({ BMADBridge } = await (0, lib_resolver_js_1.importLibModule)('bmad-bridge.js'));
     }
     if (!DeliverableGenerator) {
-      ({ DeliverableGenerator } = await import(
-        path.join(libDirectory, 'deliverable-generator.js')
+      ({ DeliverableGenerator } = await (0, lib_resolver_js_1.importLibModule)(
+        'deliverable-generator.js',
       ));
     }
     if (!BrownfieldAnalyzer) {
-      ({ BrownfieldAnalyzer } = await import(path.join(libDirectory, 'brownfield-analyzer.js')));
+      ({ BrownfieldAnalyzer } = await (0, lib_resolver_js_1.importLibModule)(
+        'brownfield-analyzer.js',
+      ));
     }
     if (!QuickLane) {
-      ({ QuickLane } = await import(path.join(libDirectory, 'quick-lane.js')));
+      ({ QuickLane } = await (0, lib_resolver_js_1.importLibModule)('quick-lane.js'));
     }
     if (!LaneSelector) {
-      LaneSelector = await import(path.join(libDirectory, 'lane-selector.js'));
+      LaneSelector = await (0, lib_resolver_js_1.importLibModule)('lane-selector.js');
     }
     if (!phaseTransitionHooks) {
-      phaseTransitionHooks = await import(path.join(hooksDirectory, 'phase-transition.js'));
+      phaseTransitionHooks = await (0, lib_resolver_js_1.importFromPackageRoot)(
+        'hooks',
+        'phase-transition.js',
+      );
     }
     if (!contextPreservation) {
-      contextPreservation = await import(path.join(hooksDirectory, 'context-preservation.js'));
+      contextPreservation = await (0, lib_resolver_js_1.importFromPackageRoot)(
+        'hooks',
+        'context-preservation.js',
+      );
     }
     if (!storyContextValidator) {
-      const module = await import(path.join(libDirectory, 'story-context-validator.js'));
+      const module = await (0, lib_resolver_js_1.importLibModule)('story-context-validator.js');
       storyContextValidator = module?.default ?? module;
     }
   }


### PR DESCRIPTION
## Summary
- replace the Codex runtime's manual repository path resolution with the shared lib-resolver helpers and drop the redundant direct auto-commands require
- regenerate the compiled Codex runtime artifacts so their imports use the helper APIs for lib and hook modules

## Testing
- npm run build:mcp
- (in a separate project) timeout 3 node dist/codex/runtime.js

------
https://chatgpt.com/codex/tasks/task_e_68dfabce36908326b99f7d2edda40974