### PR TITLE
Add lane scale metadata to lane decisions

### DIFF
--- a/dist/codex/runtime.js
+++ b/dist/codex/runtime.js
@@ -1246,10 +1246,16 @@ async function runOrchestratorServer(options = {}) {
             projectState.projectPath,
           );
           const selectionDurationMs = selectionTimer();
+          const scaleLevel = decision.scale?.level;
+          const scaleScore = decision.scale?.score;
+          const scaleSignals = decision.scale?.signals;
           logger.info('lane_selection_completed', {
             operation: 'select_development_lane',
             lane: decision.lane,
             confidence: decision.confidence,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
             durationMs: selectionDurationMs,
           });
           logger.recordTiming('mcp.lane.selection.duration_ms', selectionDurationMs, {
@@ -1261,16 +1267,33 @@ async function runOrchestratorServer(options = {}) {
             decision.rationale,
             decision.confidence,
             params.userMessage,
+            {
+              level: scaleLevel,
+              levelScore: scaleScore,
+              levelSignals: scaleSignals,
+            },
           );
           laneDecisions.push({
             lane: decision.lane,
             rationale: decision.rationale,
             confidence: decision.confidence,
             trigger: params.userMessage,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
           });
           outcomeFields.lane = decision.lane;
           outcomeFields.confidence = decision.confidence;
           outcomeFields.trigger = params.userMessage;
+          if (scaleLevel !== undefined) {
+            outcomeFields.level = scaleLevel;
+          }
+          if (scaleScore !== undefined) {
+            outcomeFields.levelScore = scaleScore;
+          }
+          if (scaleSignals !== undefined) {
+            outcomeFields.levelSignals = scaleSignals;
+          }
           response = {
             content: [
               {
@@ -1295,10 +1318,16 @@ async function runOrchestratorServer(options = {}) {
             projectState.projectPath,
           );
           const selectionDurationMs = selectionTimer();
+          const scaleLevel = decision.scale?.level;
+          const scaleScore = decision.scale?.score;
+          const scaleSignals = decision.scale?.signals;
           logger.info('lane_selection_completed', {
             operation: 'execute_workflow',
             lane: decision.lane,
             confidence: decision.confidence,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
             durationMs: selectionDurationMs,
           });
           logger.recordTiming('mcp.lane.selection.duration_ms', selectionDurationMs, {
@@ -1310,17 +1339,34 @@ async function runOrchestratorServer(options = {}) {
             decision.rationale,
             decision.confidence,
             params.userRequest,
+            {
+              level: scaleLevel,
+              levelScore: scaleScore,
+              levelSignals: scaleSignals,
+            },
           );
           laneDecisions.push({
             lane: decision.lane,
             rationale: decision.rationale,
             confidence: decision.confidence,
             trigger: params.userRequest,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
           });
           let result;
           outcomeFields.lane = decision.lane;
           outcomeFields.confidence = decision.confidence;
           outcomeFields.request = params.userRequest;
+          if (scaleLevel !== undefined) {
+            outcomeFields.level = scaleLevel;
+          }
+          if (scaleScore !== undefined) {
+            outcomeFields.levelScore = scaleScore;
+          }
+          if (scaleSignals !== undefined) {
+            outcomeFields.levelSignals = scaleSignals;
+          }
           if (decision.lane === 'quick') {
             await ensureOperationAllowed('execute_quick_lane', {
               decision,

--- a/dist/mcp/src/mcp-server/runtime.js
+++ b/dist/mcp/src/mcp-server/runtime.js
@@ -1246,10 +1246,16 @@ async function runOrchestratorServer(options = {}) {
             projectState.projectPath,
           );
           const selectionDurationMs = selectionTimer();
+          const scaleLevel = decision.scale?.level;
+          const scaleScore = decision.scale?.score;
+          const scaleSignals = decision.scale?.signals;
           logger.info('lane_selection_completed', {
             operation: 'select_development_lane',
             lane: decision.lane,
             confidence: decision.confidence,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
             durationMs: selectionDurationMs,
           });
           logger.recordTiming('mcp.lane.selection.duration_ms', selectionDurationMs, {
@@ -1261,16 +1267,33 @@ async function runOrchestratorServer(options = {}) {
             decision.rationale,
             decision.confidence,
             params.userMessage,
+            {
+              level: scaleLevel,
+              levelScore: scaleScore,
+              levelSignals: scaleSignals,
+            },
           );
           laneDecisions.push({
             lane: decision.lane,
             rationale: decision.rationale,
             confidence: decision.confidence,
             trigger: params.userMessage,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
           });
           outcomeFields.lane = decision.lane;
           outcomeFields.confidence = decision.confidence;
           outcomeFields.trigger = params.userMessage;
+          if (scaleLevel !== undefined) {
+            outcomeFields.level = scaleLevel;
+          }
+          if (scaleScore !== undefined) {
+            outcomeFields.levelScore = scaleScore;
+          }
+          if (scaleSignals !== undefined) {
+            outcomeFields.levelSignals = scaleSignals;
+          }
           response = {
             content: [
               {
@@ -1295,10 +1318,16 @@ async function runOrchestratorServer(options = {}) {
             projectState.projectPath,
           );
           const selectionDurationMs = selectionTimer();
+          const scaleLevel = decision.scale?.level;
+          const scaleScore = decision.scale?.score;
+          const scaleSignals = decision.scale?.signals;
           logger.info('lane_selection_completed', {
             operation: 'execute_workflow',
             lane: decision.lane,
             confidence: decision.confidence,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
             durationMs: selectionDurationMs,
           });
           logger.recordTiming('mcp.lane.selection.duration_ms', selectionDurationMs, {
@@ -1310,17 +1339,34 @@ async function runOrchestratorServer(options = {}) {
             decision.rationale,
             decision.confidence,
             params.userRequest,
+            {
+              level: scaleLevel,
+              levelScore: scaleScore,
+              levelSignals: scaleSignals,
+            },
           );
           laneDecisions.push({
             lane: decision.lane,
             rationale: decision.rationale,
             confidence: decision.confidence,
             trigger: params.userRequest,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
           });
           let result;
           outcomeFields.lane = decision.lane;
           outcomeFields.confidence = decision.confidence;
           outcomeFields.request = params.userRequest;
+          if (scaleLevel !== undefined) {
+            outcomeFields.level = scaleLevel;
+          }
+          if (scaleScore !== undefined) {
+            outcomeFields.levelScore = scaleScore;
+          }
+          if (scaleSignals !== undefined) {
+            outcomeFields.levelSignals = scaleSignals;
+          }
           if (decision.lane === 'quick') {
             await ensureOperationAllowed('execute_quick_lane', {
               decision,

--- a/lib/project-state.js
+++ b/lib/project-state.js
@@ -589,11 +589,12 @@ class ProjectState {
   /**
    * Record a lane decision
    */
-  async recordLaneDecision(lane, rationale, confidence, userMessage = '') {
+  async recordLaneDecision(lane, rationale, confidence, userMessage = '', options = {}) {
     if (!this.state.laneHistory) {
       this.state.laneHistory = [];
     }
 
+    const { level, levelScore, levelSignals } = options || {};
     const decision = {
       lane,
       rationale,
@@ -602,6 +603,16 @@ class ProjectState {
       timestamp: new Date().toISOString(),
       phase: this.state.currentPhase,
     };
+
+    if (level !== undefined) {
+      decision.level = level;
+    }
+    if (levelScore !== undefined) {
+      decision.levelScore = levelScore;
+    }
+    if (levelSignals !== undefined) {
+      decision.levelSignals = levelSignals;
+    }
 
     this.state.laneHistory.push(decision);
     this.state.currentLane = lane;

--- a/src/mcp-server/runtime.ts
+++ b/src/mcp-server/runtime.ts
@@ -308,6 +308,9 @@ interface LaneDecisionRecord {
   rationale?: string;
   confidence?: number;
   trigger?: string;
+  level?: number;
+  levelScore?: number;
+  levelSignals?: unknown;
 }
 
 interface ReviewCheckpointConfig {
@@ -1527,10 +1530,16 @@ export async function runOrchestratorServer(
           );
 
           const selectionDurationMs = selectionTimer();
+          const scaleLevel = decision.scale?.level;
+          const scaleScore = decision.scale?.score;
+          const scaleSignals = decision.scale?.signals;
           logger.info("lane_selection_completed", {
             operation: "select_development_lane",
             lane: decision.lane,
             confidence: decision.confidence,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
             durationMs: selectionDurationMs,
           });
           logger.recordTiming("mcp.lane.selection.duration_ms", selectionDurationMs, {
@@ -1542,7 +1551,12 @@ export async function runOrchestratorServer(
             decision.lane,
             decision.rationale,
             decision.confidence,
-            params.userMessage
+            params.userMessage,
+            {
+              level: scaleLevel,
+              levelScore: scaleScore,
+              levelSignals: scaleSignals,
+            }
           );
 
           laneDecisions.push({
@@ -1550,11 +1564,23 @@ export async function runOrchestratorServer(
             rationale: decision.rationale,
             confidence: decision.confidence,
             trigger: params.userMessage,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
           });
 
           outcomeFields.lane = decision.lane;
           outcomeFields.confidence = decision.confidence;
           outcomeFields.trigger = params.userMessage;
+          if (scaleLevel !== undefined) {
+            outcomeFields.level = scaleLevel;
+          }
+          if (scaleScore !== undefined) {
+            outcomeFields.levelScore = scaleScore;
+          }
+          if (scaleSignals !== undefined) {
+            outcomeFields.levelSignals = scaleSignals;
+          }
 
           response = {
             content: [
@@ -1583,10 +1609,16 @@ export async function runOrchestratorServer(
           );
 
           const selectionDurationMs = selectionTimer();
+          const scaleLevel = decision.scale?.level;
+          const scaleScore = decision.scale?.score;
+          const scaleSignals = decision.scale?.signals;
           logger.info("lane_selection_completed", {
             operation: "execute_workflow",
             lane: decision.lane,
             confidence: decision.confidence,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
             durationMs: selectionDurationMs,
           });
           logger.recordTiming("mcp.lane.selection.duration_ms", selectionDurationMs, {
@@ -1598,7 +1630,12 @@ export async function runOrchestratorServer(
             decision.lane,
             decision.rationale,
             decision.confidence,
-            params.userRequest
+            params.userRequest,
+            {
+              level: scaleLevel,
+              levelScore: scaleScore,
+              levelSignals: scaleSignals,
+            }
           );
 
           laneDecisions.push({
@@ -1606,6 +1643,9 @@ export async function runOrchestratorServer(
             rationale: decision.rationale,
             confidence: decision.confidence,
             trigger: params.userRequest,
+            level: scaleLevel,
+            levelScore: scaleScore,
+            levelSignals: scaleSignals,
           });
 
           let result: any;
@@ -1613,6 +1653,15 @@ export async function runOrchestratorServer(
           outcomeFields.lane = decision.lane;
           outcomeFields.confidence = decision.confidence;
           outcomeFields.request = params.userRequest;
+          if (scaleLevel !== undefined) {
+            outcomeFields.level = scaleLevel;
+          }
+          if (scaleScore !== undefined) {
+            outcomeFields.levelScore = scaleScore;
+          }
+          if (scaleSignals !== undefined) {
+            outcomeFields.levelSignals = scaleSignals;
+          }
 
           if (decision.lane === "quick") {
             await ensureOperationAllowed("execute_quick_lane", {


### PR DESCRIPTION
## Summary
- capture lane scale metadata when selecting development lanes, updating logs, project state history, and compiled runtimes
- persist optional scale level details when recording lane decisions
- extend integration tests with mocks and assertions that exercise the new metadata

## Testing
- npm test -- --runTestsByPath test/run-orchestrator-server.integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dfb0041c848326bfdf6070cec6c041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Responses may now include level, levelScore, and levelSignals on lane decisions when available, providing clearer insight into decision confidence and criteria.
  - Logs and telemetry events include the same metadata for improved observability.
  - Backward compatible: existing workflows continue to function without providing these fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->