### PR TITLE
feat: wire GLM provider flags through CLI and docs

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -17,6 +17,8 @@ mkdir my-project && cd my-project
 
 You'll be prompted to choose between Claude, Codex, or OpenCode. Or pass
 `--assistant=claude`, `--assistant=codex`, or `--assistant=opencode` to skip the prompt.
+Need ZhipuAI's GLM? Add `--glm` / `--llm-provider=glm` (requires `ZHIPUAI_API_KEY`
+or `GLM_API_KEY`). Use `--anthropic` when you want to switch back to Claude.
 
 ```bash
 # Run this ONE command - it does everything!
@@ -52,10 +54,12 @@ npm install
 
 # Start chatting (prompts for your choice)
 npm run bmad
+# Force GLM for the orchestrator (requires ZHIPUAI_API_KEY or GLM_API_KEY)
+# npm run bmad -- --glm
 # OR use explicit commands:
-# npm run bmad:claude
-# npm run bmad:codex
-# npm run bmad:opencode
+# npm run bmad:claude    # respects --glm/--anthropic flags
+# npm run bmad:codex     # respects --glm/--anthropic flags
+# npm run bmad:opencode  # respects --glm/--anthropic flags
 
 ```
 
@@ -70,6 +74,7 @@ cd your-project
 bmad-invisible init
 bmad-invisible build
 
+# Add --glm / --llm-provider=glm to default to GLM
 bmad-invisible start
 
 ```
@@ -91,6 +96,24 @@ npm run build:mcp
 # Start conversation (prompts for choice)
 npm run bmad
 ```
+
+#### Choosing Your LLM Provider (GLM vs Anthropic)
+
+- Pass `--glm` (alias `--llm-provider=glm`) with any command to run on ZhipuAI's
+  GLM. Provide `ZHIPUAI_API_KEY` or `GLM_API_KEY` in your environment.
+- Override the model via `--llm-model=<model>` or `LLM_MODEL`.
+- Persist defaults by committing a `.env` file alongside your project:
+
+  ```bash
+  # .env
+  LLM_PROVIDER=glm
+  ZHIPUAI_API_KEY=sk-...
+  LLM_MODEL=glm-4-plus
+  ```
+
+- Swap back to Anthropic with `--anthropic` or `LLM_PROVIDER=claude`.
+- The launcher injects these overrides only into the spawned CLI so your shell
+  environment stays untouched.
 
 > **MCP Config Formats**
 >
@@ -128,6 +151,7 @@ npm run bmad                    # Start conversation (prompts for assistant choi
 npm run bmad:claude             # Start Claude directly
 npm run bmad:codex              # Start Codex directly
 npm run bmad:opencode           # Start OpenCode directly
+# Append -- --glm (or -- --anthropic) to any npm script to swap providers
 
 npx bmad-invisible test         # Run tests
 npx bmad-invisible validate     # Validate config

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ The orchestrator automatically selects the appropriate lane based on task comple
 npx bmad-invisible@latest start
 ```
 
-> Prefer a specific CLI? Append `--assistant=claude`, `--assistant=codex`, or `--assistant=opencode` to skip the prompt.
+> Prefer a specific CLI? Append `--assistant=claude`, `--assistant=codex`, or `--assistant=opencode` to skip the prompt. Add `--glm`
+> (or the explicit `--llm-provider=glm`) to swap the orchestrator to ZhipuAI's GLM using the `ZHIPUAI_API_KEY`/`GLM_API_KEY`
+> credentials. Use `--anthropic` (or `--llm-provider=claude`) anytime you want to switch back to the Anthropic defaults.
 
 That's it! This command will:
 
@@ -81,11 +83,13 @@ npm install
 
 
 # Start chatting through your preferred CLI
-npm run bmad              # Prompts you to choose
+npm run bmad              # Prompts you to choose assistant
+# Force GLM for the orchestrator (requires ZHIPUAI_API_KEY or GLM_API_KEY)
+# npm run bmad -- --glm
 # OR use explicit commands:
-# npm run bmad:claude     # Claude
-# npm run bmad:codex      # Codex
-# npm run bmad:opencode   # OpenCode
+# npm run bmad:claude     # Claude front-end (respects --glm/--anthropic)
+# npm run bmad:codex      # Codex front-end (respects --glm/--anthropic)
+# npm run bmad:opencode   # OpenCode front-end (respects --glm/--anthropic)
 
 ```
 
@@ -102,6 +106,7 @@ bmad-invisible init
 bmad-invisible build
 
 # Start chat (will prompt for assistant choice)
+# Add --glm / --llm-provider=glm to default to ZhipuAI GLM
 bmad-invisible start
 
 ```
@@ -125,6 +130,23 @@ npm run bmad
 ```
 
 > **Note**: This uses the Model Context Protocol (MCP) so you can work locally without managing API keys.
+
+#### Choosing Your LLM Provider (GLM vs Anthropic)
+
+- Run any CLI command with `--glm` (or the explicit `--llm-provider=glm`) to switch the orchestrator to ZhipuAI's GLM stack.
+- Provide credentials via environment variables – `ZHIPUAI_API_KEY` is preferred, but `GLM_API_KEY` is also detected automatically.
+- Optional model overrides can be set with `--llm-model=<model>` or by exporting `LLM_MODEL`.
+- Persist defaults in a `.env` file at your project root:
+
+  ```bash
+  # .env
+  LLM_PROVIDER=glm
+  ZHIPUAI_API_KEY=sk-...
+  LLM_MODEL=glm-4-plus   # Optional custom model
+  ```
+
+- To switch back to Anthropic at any time, pass `--anthropic` on the CLI or set `LLM_PROVIDER=claude` in your environment.
+- The launcher never mutates your shell environment; overrides are injected only into the spawned CLI process.
 
 #### Codex CLI Integration
 
@@ -510,7 +532,8 @@ User → Codex CLI → MCP Server → BMAD Agents → Deliverables
 - **BMAD Bridge** (`lib/bmad-bridge.js`) - Integration with BMAD agents
 - **Deliverable Generator** (`lib/deliverable-generator.js`) - Creates docs automatically
 
-**No API Costs** - Runs entirely through your local Codex CLI session!
+**Low API Overhead** - Runs through your local CLI tooling. ZhipuAI's GLM only needs `ZHIPUAI_API_KEY`/`GLM_API_KEY`; Anthropic
+defaults continue to work via the Claude CLI with no direct API billing.
 
 ## 🔧 Development Setup
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -11,7 +11,10 @@ npx bmad-invisible@latest start
 
 This does everything: creates structure, installs dependencies, and launches chat!
 You'll be prompted to pick Codex, Claude, or OpenCode (defaults to Codex). Use
-`--assistant=<choice>` to skip the prompt.
+`--assistant=<choice>` to skip the prompt. Add `--glm` / `--llm-provider=glm`
+to launch the orchestrator against ZhipuAI's GLM using the
+`ZHIPUAI_API_KEY`/`GLM_API_KEY` credentials, or `--anthropic` to force the
+legacy Claude defaults.
 
 > **💡 Tip**: Always use `@latest` to get the newest version!
 
@@ -29,6 +32,7 @@ npm install
 # Claude: npm run bmad:chat
 # OpenCode: npx bmad-invisible opencode
 npm run bmad:chat
+# Add -- --glm to any npm script invocation to switch providers
 ```
 
 > **UI Toolkit Opt-in**: When you include the optional shadcn UI helpers, the
@@ -48,6 +52,26 @@ npm install
 npm run build:mcp
 npm run chat
 ```
+
+### Selecting Your LLM Provider
+
+- Use `--glm` (alias for `--llm-provider=glm`) with any BMAD CLI command to run
+  the orchestrator on ZhipuAI's GLM. Provide credentials via `ZHIPUAI_API_KEY`
+  or the fallback `GLM_API_KEY`.
+- Override the model with `--llm-model=<model>` or by exporting `LLM_MODEL`.
+- Persist defaults in a `.env` file so every spawn inherits them:
+
+  ```bash
+  # .env
+  LLM_PROVIDER=glm
+  ZHIPUAI_API_KEY=sk-...
+  LLM_MODEL=glm-4-plus
+  ```
+
+- Switching back to Anthropic is as simple as passing `--anthropic` or
+  re-exporting `LLM_PROVIDER=claude`.
+- The launcher injects overrides only into the child process, so your shell
+  environment remains untouched.
 
 ## How It Works
 
@@ -311,12 +335,14 @@ docs/                  # Your deliverables
 
 Resume later - state persists!
 
-## No API Costs
+## Provider & API Costs
 
-✅ Uses your Claude Pro subscription
-✅ Works with Claude Code CLI
-✅ No Anthropic API key needed
-✅ No usage limits beyond your plan
+✅ Claude flows ride on your Claude Code subscription – no additional API key
+management required.
+✅ GLM flows require a `ZHIPUAI_API_KEY` (or `GLM_API_KEY`) but the launcher
+passes it through only to the spawned CLI.
+✅ Use `--anthropic` or `LLM_PROVIDER=claude` whenever you want to revert to the
+Anthropic defaults.
 
 ## Support
 

--- a/bin/bmad-invisible
+++ b/bin/bmad-invisible
@@ -19,6 +19,124 @@ let command;
 let args = [];
 const packageRoot = path.join(__dirname, '..');
 
+const createDefaultRuntimeOptions = () => ({
+  llmProvider: undefined,
+  llmModel: undefined,
+});
+
+let runtimeOptions = createDefaultRuntimeOptions();
+
+const VALID_LLM_PROVIDERS = new Set(['claude', 'glm', 'openai', 'gpt', 'gemini', 'google']);
+
+const normalizeLlmProvider = (value) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.toLowerCase();
+
+  if (normalized === 'anthropic') {
+    return 'claude';
+  }
+
+  if (normalized === 'zhipu') {
+    return 'glm';
+  }
+
+  return normalized;
+};
+
+const parseLlmOptionsFromArgs = (currentArgs) => {
+  let provider;
+  let model;
+  const sanitized = [];
+
+  for (let index = 0; index < currentArgs.length; index += 1) {
+    const arg = currentArgs[index];
+
+    if (arg === '--glm') {
+      provider = 'glm';
+      continue;
+    }
+
+    if (arg === '--anthropic') {
+      provider = 'claude';
+      continue;
+    }
+
+    if (arg === '--llm-provider') {
+      provider = currentArgs[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--llm-provider=')) {
+      provider = arg.split('=')[1];
+      continue;
+    }
+
+    if (arg === '--llm-model') {
+      model = currentArgs[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--llm-model=')) {
+      model = arg.split('=')[1];
+      continue;
+    }
+
+    sanitized.push(arg);
+  }
+
+  return { provider: normalizeLlmProvider(provider), model, sanitized };
+};
+
+const consumeLlmOptionsFromArgs = () => {
+  if (!args.length) {
+    return;
+  }
+
+  const { provider, model, sanitized } = parseLlmOptionsFromArgs(args);
+  args.splice(0, args.length, ...sanitized);
+
+  if (provider) {
+    if (!VALID_LLM_PROVIDERS.has(provider)) {
+      console.error('⚠️ Unsupported LLM provider flag value:', provider);
+      console.error('Valid providers:', Array.from(VALID_LLM_PROVIDERS).join(', '));
+      process.exit(1);
+      return;
+    }
+
+    runtimeOptions.llmProvider = provider;
+  }
+
+  if (model) {
+    runtimeOptions.llmModel = model;
+  }
+};
+
+const buildSpawnEnv = () => {
+  const env = { ...process.env };
+
+  if (runtimeOptions.llmProvider) {
+    env.LLM_PROVIDER = runtimeOptions.llmProvider;
+
+    if (runtimeOptions.llmProvider === 'glm') {
+      const existingKey = env.ZHIPUAI_API_KEY || env.GLM_API_KEY;
+      if (existingKey && !env.ZHIPUAI_API_KEY) {
+        env.ZHIPUAI_API_KEY = existingKey;
+      }
+    }
+  }
+
+  if (runtimeOptions.llmModel) {
+    env.LLM_MODEL = runtimeOptions.llmModel;
+  }
+
+  return env;
+};
+
 // Get current package version
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
 const currentVersion = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version;
@@ -29,6 +147,13 @@ BMAD Invisible - Zero-knowledge AI orchestration (v${currentVersion})
 
 Usage:
   npx bmad-invisible@latest <command> [options]
+
+Options:
+  --assistant=<assistant>    Launch specified CLI front-end (claude, codex, opencode)
+  --llm-provider=<provider>  Override orchestrator LLM (claude, glm, openai, gemini)
+  --llm-model=<model>        Force a specific model id for the orchestrator
+  --glm                      Shortcut for --llm-provider=glm (uses ZHIPUAI_API_KEY)
+  --anthropic                Shortcut for --llm-provider=claude
 
 Commands:
 
@@ -49,12 +174,18 @@ Examples:
   npx bmad-invisible@latest start      # 🚀 Do everything in one command!
   npx bmad-invisible@latest start --assistant=opencode
                                       # Skip the prompt and launch OpenCode
+  npx bmad-invisible@latest start --glm
+                                      # Use GLM with ZHIPUAI_API_KEY / GLM_API_KEY
   npx bmad-invisible@latest init       # Setup in current project
   npm run codex                        # Start conversation (after install)
 
 
 💡 Tip: Always use @latest to get the newest version:
    npx bmad-invisible@latest start
+
+Environment:
+  Set ZHIPUAI_API_KEY (or GLM_API_KEY) and optionally LLM_MODEL when using --glm.
+  Use --anthropic or LLM_PROVIDER=claude to switch back to Anthropic defaults.
 
 For more information: https://github.com/bacoco/BMAD-invisible
 `);
@@ -189,6 +320,8 @@ const determineAssistant = async (flagValue) => {
 const commands = {
   start: async () => {
     console.log('🚀 Starting BMAD-invisible setup...\n');
+
+    consumeLlmOptionsFromArgs();
 
     // Determine assistant preference before installation begins
     const { assistant: assistantFlag, sanitized } = parseAssistantFromArgs(args);
@@ -589,6 +722,8 @@ For detailed documentation, visit:
   },
 
   codex: async () => {
+    consumeLlmOptionsFromArgs();
+
     const localInstall = path.join(process.cwd(), 'node_modules', 'bmad-invisible');
     const codexScript = fs.existsSync(localInstall)
       ? path.join(localInstall, 'bin', 'bmad-codex')
@@ -603,6 +738,7 @@ For detailed documentation, visit:
     const child = spawn('node', [codexScript, ...args], {
       stdio: 'inherit',
       cwd: process.cwd(),
+      env: buildSpawnEnv(),
     });
 
     child.on('error', (error) => {
@@ -616,6 +752,8 @@ For detailed documentation, visit:
   },
 
   chat: async () => {
+    consumeLlmOptionsFromArgs();
+
     // Check if bmad-invisible is installed locally first
     const localInstall = path.join(process.cwd(), 'node_modules', 'bmad-invisible');
     const chatScript = fs.existsSync(localInstall)
@@ -631,6 +769,7 @@ For detailed documentation, visit:
     const child = spawn('node', [chatScript, ...args], {
       stdio: 'inherit',
       cwd: process.cwd(),
+      env: buildSpawnEnv(),
     });
 
     child.on('error', (error) => {
@@ -644,10 +783,13 @@ For detailed documentation, visit:
   },
 
   opencode: async () => {
+    consumeLlmOptionsFromArgs();
+
     const child = spawn('opencode', args, {
       stdio: 'inherit',
       cwd: process.cwd(),
       shell: false,
+      env: buildSpawnEnv(),
     });
 
     child.on('error', (error) => {
@@ -741,12 +883,14 @@ For detailed documentation, visit:
   },
 };
 
-const setRuntimeContext = (nextCommand, nextArgs = []) => {
+const setRuntimeContext = (nextCommand, nextArgs = [], options = {}) => {
   command = nextCommand;
   args = Array.isArray(nextArgs) ? [...nextArgs] : [];
+  runtimeOptions = { ...createDefaultRuntimeOptions(), ...(options.runtimeOptions || {}) };
 };
 
 const run = (argv = process.argv) => {
+  runtimeOptions = createDefaultRuntimeOptions();
   [, , command, ...args] = argv;
 
   if (!command || command === '--help' || command === '-h') {

--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -34,6 +34,9 @@ class LLMClient {
       case 'google': {
         return process.env.GOOGLE_API_KEY;
       }
+      case 'glm': {
+        return process.env.ZHIPUAI_API_KEY || process.env.GLM_API_KEY;
+      }
       default: {
         throw new Error(`Unknown LLM provider: ${this.provider}`);
       }
@@ -53,6 +56,9 @@ class LLMClient {
       case 'google': {
         return 'GOOGLE_API_KEY';
       }
+      case 'glm': {
+        return 'ZHIPUAI_API_KEY';
+      }
       default: {
         return 'LLM_API_KEY';
       }
@@ -71,6 +77,9 @@ class LLMClient {
       case 'gemini':
       case 'google': {
         return 'gemini-1.5-pro';
+      }
+      case 'glm': {
+        return 'glm-4-plus';
       }
       default: {
         return 'claude-3-5-sonnet-20241022';
@@ -111,6 +120,13 @@ class LLMClient {
           case 'gemini':
           case 'google': {
             return await this.chatGemini(messages, {
+              systemPrompt,
+              temperature,
+              maxTokens,
+            });
+          }
+          case 'glm': {
+            return await this.chatGLM(messages, {
               systemPrompt,
               temperature,
               maxTokens,
@@ -234,6 +250,57 @@ class LLMClient {
     );
 
     return response.candidates[0].content.parts[0].text;
+  }
+
+  async chatGLM(messages, options) {
+    const apiMessages = messages.map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+    }));
+
+    if (options.systemPrompt) {
+      apiMessages.unshift({
+        role: 'system',
+        content: options.systemPrompt,
+      });
+    }
+
+    const payload = {
+      model: this.model,
+      messages: apiMessages,
+      temperature: options.temperature,
+      max_tokens: options.maxTokens,
+    };
+
+    const response = await this.makeRequest(
+      'open.bigmodel.cn',
+      '/api/paas/v4/chat/completions',
+      'POST',
+      payload,
+      {
+        Authorization: `Bearer ${this.apiKey}`,
+        Accept: 'application/json',
+      },
+    );
+
+    const choice = response?.choices?.[0];
+    if (!choice) {
+      throw new Error('GLM response did not include any choices.');
+    }
+
+    if (typeof choice.message?.content === 'string') {
+      return choice.message.content;
+    }
+
+    if (Array.isArray(choice.message?.content)) {
+      return choice.message.content.map((part) => part.text || part).join('');
+    }
+
+    if (choice.message?.text) {
+      return choice.message.text;
+    }
+
+    throw new Error('Unable to extract content from GLM response.');
   }
 
   makeRequest(hostname, path, method, body, headers) {

--- a/test/bmad-invisible-cli.test.js
+++ b/test/bmad-invisible-cli.test.js
@@ -15,6 +15,7 @@ describe('bmad-invisible start assistant selection', () => {
   let exitSpy;
   let existsSpy;
   let originalIsTTY;
+  const originalEnv = process.env;
 
   beforeEach(() => {
     mockSpawn.mockReset();
@@ -31,6 +32,11 @@ describe('bmad-invisible start assistant selection', () => {
     existsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
     exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
     originalIsTTY = process.stdout.isTTY;
+    process.env = { ...originalEnv };
+    delete process.env.LLM_PROVIDER;
+    delete process.env.LLM_MODEL;
+    delete process.env.ZHIPUAI_API_KEY;
+    delete process.env.GLM_API_KEY;
   });
 
   afterEach(() => {
@@ -38,6 +44,7 @@ describe('bmad-invisible start assistant selection', () => {
     existsSpy.mockRestore();
     exitSpy.mockRestore();
     process.stdout.isTTY = originalIsTTY;
+    process.env = originalEnv;
   });
 
   test('errors in non-TTY mode when no assistant flag is provided', async () => {
@@ -70,6 +77,7 @@ describe('bmad-invisible start assistant selection', () => {
     expect(lastCall[0]).toBe('opencode');
     expect(lastCall[1]).toEqual([]);
     expect(lastCall[2].shell).toBe(false);
+    expect(lastCall[2].env.LLM_PROVIDER).toBeUndefined();
   });
 
   test('handles invalid assistant flag by exiting with error', async () => {
@@ -83,7 +91,7 @@ describe('bmad-invisible start assistant selection', () => {
   });
 
   test('handles spawn error for Codex', async () => {
-    const mockErrorSpawn = jest.fn(() => {
+    mockSpawn.mockImplementationOnce(() => {
       const emitter = {
         on: jest.fn((event, handler) => {
           if (event === 'error') {
@@ -95,21 +103,14 @@ describe('bmad-invisible start assistant selection', () => {
       return emitter;
     });
 
-    jest.isolateModules(() => {
-      jest.doMock('child_process', () => ({
-        spawn: mockErrorSpawn,
-      }));
+    cli.setRuntimeContext('codex', []);
 
-      const cliWithError = require('../bin/bmad-invisible');
-      cli.setRuntimeContext('codex', []);
-
-      expect(() => cliWithError.commands.codex()).not.toThrow();
-      expect(exitSpy).toHaveBeenCalledWith(1);
-    });
+    expect(() => cli.commands.codex()).not.toThrow();
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   test('handles spawn error for OpenCode', async () => {
-    const mockErrorSpawn = jest.fn(() => {
+    mockSpawn.mockImplementationOnce(() => {
       const emitter = {
         on: jest.fn((event, handler) => {
           if (event === 'error') {
@@ -121,16 +122,35 @@ describe('bmad-invisible start assistant selection', () => {
       return emitter;
     });
 
-    jest.isolateModules(() => {
-      jest.doMock('child_process', () => ({
-        spawn: mockErrorSpawn,
-      }));
+    cli.setRuntimeContext('opencode', []);
 
-      const cliWithError = require('../bin/bmad-invisible');
-      cli.setRuntimeContext('opencode', []);
+    expect(() => cli.commands.opencode()).not.toThrow();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
 
-      expect(() => cliWithError.commands.opencode()).not.toThrow();
-      expect(exitSpy).toHaveBeenCalledWith(1);
-    });
+  test('plumbs GLM provider into spawned CLI environment without mutating parent env', async () => {
+    process.env.GLM_API_KEY = 'glm-test-key';
+    cli.setRuntimeContext('start', ['--assistant=codex', '--glm']);
+
+    await cli.commands.start();
+
+    const lastCall = mockSpawn.mock.calls.at(-1);
+    expect(lastCall[2].env.LLM_PROVIDER).toBe('glm');
+    expect(lastCall[2].env.ZHIPUAI_API_KEY).toBe('glm-test-key');
+    expect(process.env.LLM_PROVIDER).toBeUndefined();
+    expect(process.env.ZHIPUAI_API_KEY).toBeUndefined();
+  });
+
+  test('direct codex command respects --llm-provider flag', async () => {
+    cli.setRuntimeContext('codex', ['--llm-provider=glm']);
+    process.env.ZHIPUAI_API_KEY = 'direct-key';
+
+    await cli.commands.codex();
+
+    const lastCall = mockSpawn.mock.calls.at(-1);
+    expect(lastCall[0]).toBe('node');
+    expect(lastCall[2].env.LLM_PROVIDER).toBe('glm');
+    expect(lastCall[2].env.ZHIPUAI_API_KEY).toBe('direct-key');
+    expect(process.env.LLM_PROVIDER).toBeUndefined();
   });
 });

--- a/test/llm-client.test.js
+++ b/test/llm-client.test.js
@@ -9,6 +9,8 @@ describe('LLMClient', () => {
     delete process.env.OPENAI_API_KEY;
     delete process.env.GOOGLE_API_KEY;
     delete process.env.LLM_PROVIDER;
+    delete process.env.ZHIPUAI_API_KEY;
+    delete process.env.GLM_API_KEY;
   });
 
   afterAll(() => {
@@ -19,5 +21,24 @@ describe('LLMClient', () => {
     expect(() => new LLMClient({ provider: 'claude' })).toThrow(
       'Missing API key for provider "claude". Set the ANTHROPIC_API_KEY environment variable or provide an apiKey option.',
     );
+  });
+
+  it('reads GLM credentials from either ZHIPUAI_API_KEY or GLM_API_KEY', () => {
+    process.env.GLM_API_KEY = 'glm-key';
+    let client;
+    expect(() => {
+      client = new LLMClient({ provider: 'glm' });
+    }).not.toThrow();
+    expect(client.apiKey).toBe('glm-key');
+
+    process.env.ZHIPUAI_API_KEY = 'zhipu-key';
+    const prioritized = new LLMClient({ provider: 'glm' });
+    expect(prioritized.apiKey).toBe('zhipu-key');
+  });
+
+  it('exposes glm default model without requiring anthropic credentials', () => {
+    process.env.ZHIPUAI_API_KEY = 'glm-key';
+    const client = new LLMClient({ provider: 'glm' });
+    expect(client.model).toBe('glm-4-plus');
   });
 });


### PR DESCRIPTION
## Summary
- document the new GLM launch flags, environment variables, and Anthropic fallback steps across README, USAGE, and QUICKSTART
- extend the CLI help/options to surface --glm/--llm-provider/--llm-model flags and plumb provider overrides into spawned child processes without mutating the parent env
- add GLM coverage to the LLM client plus smoke tests that confirm GLM provider selection is forwarded into CLI spawns

## Testing
- npx jest test/bmad-invisible-cli.test.js --runInBand
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfb260e4f48326aff8a1c0aca78869