### PR TITLE
Add GitMCP server configuration to MCP settings

### DIFF
--- a/mcp/bmad-config.json
+++ b/mcp/bmad-config.json
@@ -11,6 +11,10 @@
     "shadcn": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-shadcn"]
+    },
+    "gitmcp": {
+      "command": "npx",
+      "args": ["-y", "gitmcp", "--stdio"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a GitMCP server entry to the MCP configuration so the client can launch it via npx

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfbfd532d4832681721bfa88108b4e