### PR TITLE
Update OpenCode defaults to current Codex CLI models

### DIFF
--- a/test/opencode-setup.test.js
+++ b/test/opencode-setup.test.js
@@ -5,8 +5,8 @@ const cjson = require('comment-json');
 const ideSetup = require('../tools/installer/lib/ide-setup');
 
 // These default values must match tools/installer/lib/ide-setup.js defaultModelSettings
-const DEFAULT_MODEL = 'codex/gpt-4.1';
-const DEFAULT_FALLBACKS = ['anthropic/claude-3.5-sonnet', 'openai/gpt-4o-mini'];
+const DEFAULT_MODEL = 'openai/gpt-4.1';
+const DEFAULT_FALLBACKS = ['openai/gpt-4.1-mini', 'anthropic/claude-3.5-sonnet'];
 
 const preconfiguredSettings = {
   opencode: { useAgentPrefix: false, useCommandPrefix: false },
@@ -86,11 +86,11 @@ describe('setupOpenCode model defaults', () => {
 
       // Should preserve the original entries including empty strings (not filtered from original array)
       // Should not duplicate 'anthropic/claude-3.5-sonnet' due to case-insensitive matching
-      // Should add 'openai/gpt-4o-mini' which wasn't present
+      // Should add 'openai/gpt-4.1-mini' which wasn't present
       expect(parsed.fallbackModels).toContain('Anthropic/CLAUDE-3.5-sonnet');
       expect(parsed.fallbackModels).toContain('custom/model');
-      expect(parsed.fallbackModels).toContain('openai/gpt-4o-mini');
-      expect(parsed.fallbackModels).toHaveLength(5); // '', 'Anthropic/CLAUDE...', 'custom/model', '   ', 'openai/gpt-4o-mini'
+      expect(parsed.fallbackModels).toContain('openai/gpt-4.1-mini');
+      expect(parsed.fallbackModels).toHaveLength(5); // '', 'Anthropic/CLAUDE...', 'custom/model', '   ', 'openai/gpt-4.1-mini'
     } finally {
       await fs.remove(projectDir);
     }

--- a/tools/installer/lib/ide-setup.js
+++ b/tools/installer/lib/ide-setup.js
@@ -139,8 +139,8 @@ class IdeSetup extends BaseIdeSetup {
     // - If none exists: create minimal opencode.jsonc with $schema and instructions array including that file
 
     const defaultModelSettings = {
-      model: 'codex/gpt-4.1',
-      fallbackModels: ['anthropic/claude-3.5-sonnet', 'openai/gpt-4o-mini'],
+      model: 'openai/gpt-4.1',
+      fallbackModels: ['openai/gpt-4.1-mini', 'anthropic/claude-3.5-sonnet'],
     };
 
     const jsonPath = path.join(installDir, 'opencode.json');


### PR DESCRIPTION
## Summary
- update the OpenCode installer defaults to use the current Codex CLI model identifiers
- align the OpenCode setup test expectations with the refreshed defaults

## Testing
- npm test -- opencode-setup

------
https://chatgpt.com/codex/tasks/task_e_68dfc0dff46c8326960c005fef8447f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the default AI model used during setup to openai/gpt-4.1 and revised the fallback order to prioritize openai/gpt-4.1-mini and anthropic/claude-3.5-sonnet. New installs or resets will use the updated configuration. Existing custom settings are unaffected.

* Tests
  * Aligned test expectations and comments with the new default model and fallback list, including updated array length checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->