### PR TITLE
Handle Anthropic port in LLM client

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -309,7 +309,7 @@ class LLMClient {
     throw new Error('Unable to extract content from GLM response.');
   }
 
-  makeRequest(hostname, path, method, body, headers) {
+  makeRequest(hostname, path, method, body, headers, port) {
     return new Promise((resolve, reject) => {
       const options = {
         hostname,


### PR DESCRIPTION
## Summary
- allow the shared makeRequest helper to accept an optional port and forward it to https.request
- add a unit test that stubs https.request and asserts the Anthropic base URL port is passed through

## Testing
- npm test -- llm-client

------
https://chatgpt.com/codex/tasks/task_e_68dfc0e597f88326ba3e7e7e4c5c468f