### PR TITLE
Fix GLM provider routing in LLM client

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -102,8 +102,7 @@ class LLMClient {
     for (let attempt = 0; attempt < this.maxRetries; attempt++) {
       try {
         switch (this.provider) {
-          case 'claude':
-          case 'glm': {
+          case 'claude': {
             return await this.chatAnthropic(messages, {
               systemPrompt,
               temperature,


### PR DESCRIPTION
## Summary
- ensure the GLM provider path in the LLM client uses the GLM chat implementation
- add unit coverage verifying GLM chats invoke `chatGLM`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfdf76691c8326a7eb58714f44f89a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly routes GLM provider chats through the intended service, preventing misclassification and related errors. Users selecting GLM should now see consistent, reliable responses.

* **Tests**
  * Added tests to verify GLM chats use the correct path and that alternative providers are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->