### PR TITLE
Update build command to detect packaged MCP entry point

### DIFF
--- a/bin/bmad-invisible
+++ b/bin/bmad-invisible
@@ -1299,10 +1299,17 @@ For detailed documentation, visit:
     const rootDir = fs.existsSync(localInstall) ? localInstall : path.join(__dirname, '..');
 
     // The MCP server is already pre-built in dist/, but we'll check TypeScript is available
-    const distMcp = path.join(rootDir, 'dist', 'mcp', 'server.js');
-    if (fs.existsSync(distMcp)) {
+    const packagedEntryCandidates = [
+      path.join(rootDir, 'dist', 'mcp', 'mcp', 'server.js'),
+      path.join(rootDir, 'dist', 'mcp', 'server.js'),
+    ];
+    const resolvedPackagedEntry = packagedEntryCandidates.find((candidate) =>
+      fs.existsSync(candidate),
+    );
+
+    if (resolvedPackagedEntry) {
       console.log('✅ MCP server already built and ready!');
-      console.log(`   Location: ${distMcp}`);
+      console.log(`   Entry point: ${resolvedPackagedEntry}`);
       return;
     }
 
@@ -1315,7 +1322,13 @@ For detailed documentation, visit:
 
     child.on('exit', (code) => {
       if (code === 0) {
+        const builtEntry = packagedEntryCandidates.find((candidate) =>
+          fs.existsSync(candidate),
+        );
         console.log('\n✅ MCP server built successfully!');
+        if (builtEntry) {
+          console.log(`   Entry point: ${builtEntry}`);
+        }
       }
       process.exit(code || 0);
     });


### PR DESCRIPTION
## Summary
- ensure the build command checks the packaged MCP server entry point in the new dist/mcp/mcp/server.js location with a fallback to the legacy path
- report the resolved entry point path both when using the prebuilt package and after a successful build

## Testing
- npm exec bmad-invisible build

------
https://chatgpt.com/codex/tasks/task_e_68dfdf7cae588326bbe5da05b3def654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects multiple possible packaged MCP entry points and uses the first available.
  * Dynamically logs the actual resolved entry point instead of a static path.
  * Exits early when a packaged entry is found, improving startup flow.

* **Chores**
  * Preserves existing build behavior when no packaged entry is found.
  * After a successful build, re-checks and logs the built entry point while keeping the previous success messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->