### PR TITLE
fix: wrap anthropic message content in text blocks

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -102,8 +102,7 @@ class LLMClient {
     for (let attempt = 0; attempt < this.maxRetries; attempt++) {
       try {
         switch (this.provider) {
-          case 'claude':
-          case 'glm': {
+          case 'claude': {
             return await this.chatAnthropic(messages, {
               systemPrompt,
               temperature,
@@ -155,7 +154,12 @@ class LLMClient {
       temperature: options.temperature,
       messages: messages.map((msg) => ({
         role: msg.role,
-        content: msg.content,
+        content: [
+          {
+            type: 'text',
+            text: msg.content,
+          },
+        ],
       })),
     };
 

--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -147,6 +147,14 @@ class LLMClient {
     throw new Error(`Failed after ${this.maxRetries} attempts: ${lastError.message}`);
   }
 
+  /**
+   * Send messages to Anthropic's Claude API
+   * Messages are formatted with content blocks according to the Claude Messages API specification
+   * @see https://docs.anthropic.com/en/api/messages
+   * @param {Array} messages - Array of {role: 'user'|'assistant', content: string}
+   * @param {Object} options - Configuration options (systemPrompt, temperature, maxTokens)
+   * @returns {Promise<string>} - Response text from Claude
+   */
   async chatAnthropic(messages, options) {
     const payload = {
       model: this.model,

--- a/test/llm-client.test.js
+++ b/test/llm-client.test.js
@@ -63,6 +63,8 @@ describe('LLMClient', () => {
       }),
     };
 
+    const writeMock = jest.fn();
+
     https.request.mockImplementation((options, callback) => {
       callback(mockResponse);
 
@@ -75,7 +77,7 @@ describe('LLMClient', () => {
 
       return {
         on: jest.fn(),
-        write: jest.fn(),
+        write: writeMock,
         end: jest.fn(),
       };
     });
@@ -90,6 +92,23 @@ describe('LLMClient', () => {
     expect(https.request).toHaveBeenCalledWith(
       expect.objectContaining({ hostname: 'example.com', port: expectedPort }),
       expect.any(Function),
+    );
+
+    const sentPayload = JSON.parse(writeMock.mock.calls[0][0]);
+    expect(sentPayload).toEqual(
+      expect.objectContaining({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello',
+              },
+            ],
+          },
+        ],
+      }),
     );
   });
 });

--- a/test/llm-client.test.js
+++ b/test/llm-client.test.js
@@ -111,4 +111,74 @@ describe('LLMClient', () => {
       }),
     );
   });
+
+  it('sends correctly formatted messages through chat() method with claude provider', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+
+    const responseListeners = {};
+    const mockResponse = {
+      statusCode: 200,
+      on: jest.fn((event, handler) => {
+        responseListeners[event] = handler;
+      }),
+    };
+
+    const writeMock = jest.fn();
+
+    https.request.mockImplementation((options, callback) => {
+      callback(mockResponse);
+
+      if (responseListeners.data) {
+        responseListeners.data(JSON.stringify({ content: [{ text: 'end-to-end response' }] }));
+      }
+      if (responseListeners.end) {
+        responseListeners.end();
+      }
+
+      return {
+        on: jest.fn(),
+        write: writeMock,
+        end: jest.fn(),
+      };
+    });
+
+    const client = new LLMClient({ provider: 'claude' });
+    const result = await client.chat(
+      [
+        { role: 'user', content: 'What is 2+2?' },
+        { role: 'assistant', content: '4' },
+        { role: 'user', content: 'What is 3+3?' },
+      ],
+      {
+        systemPrompt: 'You are a helpful math assistant.',
+        temperature: 0.7,
+        maxTokens: 200,
+      },
+    );
+
+    expect(result).toBe('end-to-end response');
+
+    // Verify the full payload structure sent to Anthropic API
+    const sentPayload = JSON.parse(writeMock.mock.calls[0][0]);
+    expect(sentPayload).toEqual({
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 200,
+      temperature: 0.7,
+      system: 'You are a helpful math assistant.',
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What is 2+2?' }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: '4' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What is 3+3?' }],
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- wrap Anthropics chat messages in text blocks to match the Claude Messages API contract
- capture the HTTPS payload in the Anthropics unit test and verify the message structure
- ensure the Claude branch no longer duplicates the GLM case to satisfy linting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfdf788e0083269fa0c11c9e3f9bfe