### PR TITLE
Fix GLM routing in LLM client

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -362,14 +362,6 @@ class LLMClient {
   }
 
   getAnthropicHeaders() {
-    if (this.provider === 'glm') {
-      const authToken = process.env.ANTHROPIC_AUTH_TOKEN || process.env.GLM_API_KEY || this.apiKey;
-      return {
-        Authorization: `Bearer ${authToken}`,
-        'anthropic-version': '2023-06-01',
-      };
-    }
-
     return {
       'x-api-key': this.apiKey,
       'anthropic-version': '2023-06-01',

--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -102,8 +102,7 @@ class LLMClient {
     for (let attempt = 0; attempt < this.maxRetries; attempt++) {
       try {
         switch (this.provider) {
-          case 'claude':
-          case 'glm': {
+          case 'claude': {
             return await this.chatAnthropic(messages, {
               systemPrompt,
               temperature,

--- a/test/llm-client.test.js
+++ b/test/llm-client.test.js
@@ -21,6 +21,10 @@ describe('LLMClient', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   afterAll(() => {
     process.env = originalEnv;
   });
@@ -64,9 +68,6 @@ describe('LLMClient', () => {
     expect(result).toBe('glm-response');
     expect(glmSpy).toHaveBeenCalledTimes(1);
     expect(anthropicSpy).not.toHaveBeenCalled();
-
-    glmSpy.mockRestore();
-    anthropicSpy.mockRestore();
   });
 
   it('passes the port from ANTHROPIC_BASE_URL to https.request', async () => {

--- a/test/llm-client.test.js
+++ b/test/llm-client.test.js
@@ -50,6 +50,25 @@ describe('LLMClient', () => {
     expect(client.model).toBe('glm-4-plus');
   });
 
+  it('routes chat requests to chatGLM when provider is glm', async () => {
+    process.env.ZHIPUAI_API_KEY = 'glm-key';
+    const client = new LLMClient({ provider: 'glm' });
+
+    const glmSpy = jest.spyOn(client, 'chatGLM').mockResolvedValue('glm-response');
+    const anthropicSpy = jest
+      .spyOn(client, 'chatAnthropic')
+      .mockResolvedValue('anthropic-response');
+
+    const result = await client.chat([{ role: 'user', content: 'Hi there' }]);
+
+    expect(result).toBe('glm-response');
+    expect(glmSpy).toHaveBeenCalledTimes(1);
+    expect(anthropicSpy).not.toHaveBeenCalled();
+
+    glmSpy.mockRestore();
+    anthropicSpy.mockRestore();
+  });
+
   it('passes the port from ANTHROPIC_BASE_URL to https.request', async () => {
     const expectedPort = '8443';
     process.env.ANTHROPIC_API_KEY = 'test-key';


### PR DESCRIPTION
## Summary
- ensure GLM provider requests are routed through chatGLM instead of the Anthropic handler
- add unit coverage that spies on the GLM and Anthropic chat methods to verify routing

## Testing
- npm test -- llm-client.test.js *(fails: npm is not available in the execution environment)*
- npm run bmad -- --glm *(fails: npm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdf714a2c8326b63f194c1bb8ef22