### PR TITLE
Refine MCP postinstall build

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ npm run bmad
 # OR: npm run bmad:claude / bmad:codex / bmad:opencode
 ```
 
+> **MCP assets are prebuilt**: The published package already includes `dist/mcp`, so installs without dev dependencies (for example on Windows or production hosts) can skip rebuilding during `npm install`. The optional postinstall step only re-runs the TypeScript build when `typescript` is available.
+
 > **Note**: This uses the Model Context Protocol (MCP) so you can work locally without managing API keys.
 
 #### Choosing Your LLM Provider (GLM vs Anthropic)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "flatten": "node tools/flattener/main.js",
     "format": "prettier --write \"**/*.{js,cjs,mjs,json,md,yaml}\"",
     "format:check": "prettier --check \"**/*.{js,cjs,mjs,json,md,yaml}\"",
-    "postinstall": "npm run build:mcp 2>/dev/null || true",
+    "postinstall": "node tools/postinstall-build-mcp.js",
     "install:bmad": "node tools/installer/bin/bmad.js install",
     "lint": "eslint . --ext .js,.cjs,.mjs,.yaml --max-warnings=0",
     "lint:fix": "eslint . --ext .js,.cjs,.mjs,.yaml --fix",

--- a/tools/postinstall-build-mcp.js
+++ b/tools/postinstall-build-mcp.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const { existsSync, mkdirSync, readdirSync, copyFileSync } = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const rootDir = path.resolve(__dirname, '..');
+const distMcpDir = path.join(rootDir, 'dist', 'mcp');
+
+if (existsSync(distMcpDir)) {
+  console.log('MCP assets already exist in dist/mcp; skipping postinstall build.');
+  process.exit(0);
+}
+
+const tscBin = findTscBinary();
+
+if (tscBin) {
+  runTsc(tscBin, path.join(rootDir, 'mcp', 'tsconfig.json'));
+  runTsc(tscBin, path.join(rootDir, 'tsconfig.codex.json'));
+} else {
+  console.warn('TypeScript is not installed; skipping MCP TypeScript build.');
+}
+
+ensureDir(distMcpDir);
+
+copyDirectory(path.join(rootDir, 'lib'), path.join(distMcpDir, 'lib'));
+copyDirectory(path.join(rootDir, 'hooks'), path.join(distMcpDir, 'hooks'));
+
+function findTscBinary() {
+  try {
+    return require.resolve('typescript/bin/tsc', { paths: [rootDir] });
+  } catch {
+    return null;
+  }
+}
+
+function runTsc(tscPath, projectPath) {
+  console.log(`Running TypeScript compiler for ${projectPath}`);
+  const result = spawnSync(process.execPath, [tscPath, '-p', projectPath], {
+    stdio: 'inherit',
+    cwd: rootDir,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`TypeScript compilation failed for ${projectPath}`);
+  }
+}
+
+function ensureDir(dirPath) {
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+function copyDirectory(source, destination) {
+  if (!existsSync(source)) {
+    console.warn(`Source directory not found: ${source}`);
+    return;
+  }
+
+  ensureDir(destination);
+
+  for (const entry of readdirSync(source, { withFileTypes: true })) {
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDirectory(sourcePath, destinationPath);
+    } else if (entry.isFile()) {
+      copyFileSync(sourcePath, destinationPath);
+    } else if (entry.isSymbolicLink()) {
+      console.warn(`Skipping symbolic link during copy: ${sourcePath}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the npm postinstall command with a Node script that exits early when `dist/mcp` is already present
- add a postinstall builder that runs available TypeScript compilers and copies `lib`/`hooks` without relying on shell utilities
- document that MCP assets ship prebuilt so the postinstall step is optional when dev dependencies are missing

## Testing
- node tools/postinstall-build-mcp.js
- npm install


------
https://chatgpt.com/codex/tasks/task_e_68dfdf72af608326924a689249a8db83