### PR TITLE
Ensure fallback update-check uses package name

### DIFF
--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -23,6 +23,7 @@ try {
   console.log(`Installer context not found (${error.message}), trying root context...`);
   try {
     version = require('../../../package.json').version;
+    packageName = require('../../../package.json').name;
     installer = require('../../../tools/installer/lib/installer');
   } catch (error) {
     console.error(


### PR DESCRIPTION
## Summary
- ensure the fallback runtime context assigns the package name alongside the version
- preserve update-check messaging so it references the actual package name when run from the repo root

## Testing
- node tools/installer/bin/bmad.js update-check

------
https://chatgpt.com/codex/tasks/task_e_68dfe8cecdd483269412d7bdd18381f1