### PR TITLE
Ensure init pins dependency to current release

### DIFF
--- a/bin/bmad-invisible
+++ b/bin/bmad-invisible
@@ -1024,12 +1024,16 @@ const commands = {
     }
 
     // Add bmad-invisible as a dependency
-    const needsInstall = !packageJson.dependencies || !packageJson.dependencies['bmad-invisible'];
-    if (needsInstall) {
+    const desiredDependencyVersion = `^${currentVersion}`;
+    const existingDependencyVersion =
+      packageJson.dependencies && packageJson.dependencies['bmad-invisible'];
+    const needsDependencyUpdate = existingDependencyVersion !== desiredDependencyVersion;
+
+    if (needsDependencyUpdate) {
       packageJson.dependencies = packageJson.dependencies || {};
-      packageJson.dependencies['bmad-invisible'] = '^1.0.0';
+      packageJson.dependencies['bmad-invisible'] = desiredDependencyVersion;
       fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n');
-      console.log('✅ Added bmad-invisible to dependencies');
+      console.log(`✅ Ensured bmad-invisible@${desiredDependencyVersion} is listed in dependencies`);
     }
 
     // Only create components.json if shadcn MCP server is enabled


### PR DESCRIPTION
## Summary
- update the init command to record the current package version when adding the bmad-invisible dependency
- avoid rewriting package.json when the dependency already matches to keep install steps idempotent
- add CLI init tests that verify the dependency version and idempotent behaviour

## Testing
- npm test -- bmad-invisible-cli

------
https://chatgpt.com/codex/tasks/task_e_68dfe8ae18dc8326a697472abd0e29a5